### PR TITLE
Make some change for release to PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,6 @@ Installation
 Requirements
 ------------------
 - libpysal
-- shapely
 - descartes
 
 ***************

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ numpy>=1.3
 pandas
 matplotlib
 libpysal
-shapely
 descartes

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ REQUIREMENTS = [i.strip() for i in open(pth).readlines()]
 
 
 setup(name='pointpats',
-      version='1.0.0dev',
+      version='1.0.0',
       description='Methods and Functions for planar point pattern analysis',
       url='https://github.com/pysal/pointpats',
       maintainer='Hu Shao',


### PR DESCRIPTION
Remove the requirement of shapely. This lib only relies on shapely_ext from libpysal.
This lib is now successfully released to PyPI. See [pointpats 1.0.0](https://pypi.python.org/pypi/pointpats/1.0.0)