### PR TITLE
force UTF8 encoding for the long description read

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os.path
 
 from distutils.command.build_py import build_py
 
-with open('README.rst') as file:
+with open('README.rst', 'r', encoding='utf8') as file:
     long_description = file.read()
 
 pth = os.path.dirname(os.path.abspath(__file__))+ '/requirements.txt'


### PR DESCRIPTION
Similar to https://github.com/pysal/giddy/pull/46 to resolve potential encoding issue 