### PR TITLE
install stable released libpysal for travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,12 @@ before_install:
 
 install:
   - conda install --yes pip
+  - conda install --yes nose
   - pip install -r requirements.txt
-  - cd ../ && git clone https://github.com/pysal/libpysal.git
-  - pip install -e ./libpysal
-  - cd ./pointpats
-  - pip install -r requirements_dev.txt
 
 script:
-  - python setup.py sdist >/dev/null
-  - nosetests --with-coverage --cover-package=pointpats;
+  - nosetests --verbose --with-coverage --cover-package=pointpats;
+
 notifications:
     email:
         recipients:


### PR DESCRIPTION
Travis-CI is failing because we try to grab the [dev version of libpysal on github](https://github.com/pysal/libpysal)  https://github.com/pysal/pointpats/blob/master/.travis.yml#L23  while the libpysal API structure is now different from the released pypi version. The current configuration could make the travis testing fail very often as the libpysal API could be changing constantly.

This PR installs stable `libpysal` for travis testing instead of grabbing [pysal/libpysal](https://github.com/pysal/libpysal). Once all the API changes in libpysal are finalized and released to pypi, major changes could then be made to pointpats.