### PR TITLE
require libpysal>=4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ scipy>=0.11
 numpy>=1.3
 pandas
 matplotlib
-libpysal
+libpysal>=4.0.0


### PR DESCRIPTION
Add the required version of libpysal for pointpats: libpysal 4.0.0 is the first version released since the refactoring.