### PR TITLE
updating dual travis test procdeure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ install:
         echo 'testing pypi libpysal' && pip install libpysal;
     else
         echo 'testing git libpysal';
-        pip install https://github.com/pysal/libpysal/archive/master.zip;
+        git clone https://github.com/pysal/libpysal.git;
+        cd libpysal; pip install .; cd ../;
     fi;
 
 script:


### PR DESCRIPTION
This PR addresses the faulty dual testing schema within `.travis.yml` raised in  pysal/pysal#1145.