### PR TITLE
Make opencv package optional

### DIFF
--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -105,7 +105,7 @@ def minimum_rotated_rectangle(points, return_angle=False):
     try:
         from cv2 import minAreaRect, boxPoints
     except ModuleNotFoundError:
-        raise ModuleNotFoundError("OpenCV2 is required to use this function.")
+        raise ModuleNotFoundError("OpenCV2 is required to use this function. Please install it with `pip install opencv-contrib-python`")
     ((x, y), (w, h), angle) = rot_rect = minAreaRect(points.astype(np.float32))
     out_points = boxPoints(rot_rect)
     if return_angle:

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -104,7 +104,7 @@ def minimum_rotated_rectangle(points, return_angle=False):
     points = np.asarray(points)
     try:
         from cv2 import minAreaRect, boxPoints
-    except ModuleNotFoundError:
+    except (ImportError, ModuleNotFoundError):
         raise ModuleNotFoundError("OpenCV2 is required to use this function. Please install it with `pip install opencv-contrib-python`")
     ((x, y), (w, h), angle) = rot_rect = minAreaRect(points.astype(np.float32))
     out_points = boxPoints(rot_rect)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ numpy>=1.3
 pandas
 matplotlib
 libpysal>=4.0.0
-opencv-contrib-python>=4.2.0


### PR DESCRIPTION
As discussed in #80, the required `opencv-contrib-python` is causing issues for pysal downstream packages on conda-forge. Making `opencv-contrib-python` optional can solve the issue. Since `opencv-contrib-python` is only used by one function, it is safe to make it an optional requirement. 