### PR TITLE
handle scipy deprecation

### DIFF
--- a/ci/envs/38-minimal.yaml
+++ b/ci/envs/38-minimal.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - scipy=1.7
+  - scipy=1.8
   - numpy=1.21
   - pandas=1.3
   - matplotlib=3.4

--- a/pointpats/geometry.py
+++ b/pointpats/geometry.py
@@ -21,7 +21,7 @@ except ModuleNotFoundError:
 
 HULL_TYPES = (
     numpy.ndarray,
-    spatial.qhull.ConvexHull,
+    spatial.ConvexHull,
 )
 
 ## Define default dispatches and special dispatches without GEOS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scipy>=0.11
+scipy>=1.8.0
 numpy>=1.3
 pandas
 matplotlib


### PR DESCRIPTION
partially address https://github.com/pysal/pointpats/issues/89

handle scipy's deprecation since v1.8.0:
/Users/runner/work/pointpats/pointpats/pointpats/geometry.py:134: DeprecationWarning: Please use `ConvexHull` from the `scipy.spatial` namespace, the `scipy.spatial.qhull` namespace is deprecated.