### PR TITLE
COMPAT: ensure we pass numpy array to cKDtree and combat with sklearn 1.3.0

### DIFF
--- a/ci/envs/38-minimal.yaml
+++ b/ci/envs/38-minimal.yaml
@@ -10,7 +10,7 @@ dependencies:
   - libpysal=4.5
   - py-opencv=4.6
   # tests
-  - scikit-learn
+  - scikit-learn==1.2
   - shapely
   - geopandas
   - pytest

--- a/pointpats/geometry.py
+++ b/pointpats/geometry.py
@@ -307,11 +307,20 @@ def build_best_tree(coordinates, metric):
     coordinates = numpy.asarray(coordinates)
     tree = spatial.cKDTree
     try:
+        import sklearn
         from sklearn.neighbors import KDTree, BallTree
+        from packaging.version import Version
 
-        if metric in KDTree.valid_metrics:
+        if Version(sklearn.__version__) >= Version("1.3.0"):
+            kdtree_valid_metrics = KDTree.valid_metrics()
+            balltree_valid_metrics = BallTree.valid_metrics()
+        else:
+            kdtree_valid_metrics = KDTree.valid_metrics
+            balltree_valid_metrics = BallTree.valid_metrics
+
+        if metric in kdtree_valid_metrics:
             tree = lambda coordinates: KDTree(coordinates, metric=metric)
-        elif metric in BallTree.valid_metrics:
+        elif metric in balltree_valid_metrics:
             tree = lambda coordinates: BallTree(coordinates, metric=metric)
         elif callable(metric):
             warnings.warn(
@@ -323,8 +332,8 @@ def build_best_tree(coordinates, metric):
         else:
             raise KeyError(
                 f"Metric {metric} not found in set of available types."
-                f"BallTree metrics: {BallTree.valid_metrics}, and"
-                f"scikit KDTree metrics: {KDTree.valid_metrics}."
+                f"BallTree metrics: {balltree_valid_metrics}, and"
+                f"scikit KDTree metrics: {kdtree_valid_metrics}."
             )
     except ModuleNotFoundError as e:
         if metric not in ("l2", "euclidean"):

--- a/pointpats/pointpattern.py
+++ b/pointpats/pointpattern.py
@@ -418,9 +418,9 @@ class PointPattern(object):
         if k < 1:
             raise ValueError('k must be at least 1')
         try:
-            nn = self.tree.query(other.points, k=k)
+            nn = self.tree.query(np.asarray(other.points), k=k)
         except:
-            nn = self.tree.query(other, k=k)
+            nn = self.tree.query(np.asarray(other), k=k)
         return nn[1], nn[0]
 
     def explode(self, mark):


### PR DESCRIPTION
It seems that the DataFrame input to query worked but was never actually supported. This ensures we always cast it to a numpy array.

Closes #106 

We should probably cut a patch release with this as any env with new scipy will have this issue.