### PR TITLE
Handle scipy and pytest deprecations

### DIFF
--- a/pointpats/geometry.py
+++ b/pointpats/geometry.py
@@ -11,7 +11,7 @@ __all__ = ["area", "bbox", "contains", "k_neighbors", "build_best_tree", "prepar
 # Utilities and dispatching                                   #
 # ------------------------------------------------------------#
 
-TREE_TYPES = (spatial.KDTree, spatial.cKDTree, Arc_KDTree)
+TREE_TYPES = (spatial.KDTree, Arc_KDTree)
 try:
     from sklearn.neighbors import KDTree, BallTree
 
@@ -277,7 +277,6 @@ def build_best_tree(coordinates, metric):
     Chooses from:
     1. sklearn.KDTree if available and metric is simple
     2. sklearn.BallTree if available and metric is complicated
-    3. scipy.spatial.cKDTree if nothing else
 
     Parameters
     ----------
@@ -305,7 +304,7 @@ def build_best_tree(coordinates, metric):
         Otherwise, an error will be raised.
     """
     coordinates = numpy.asarray(coordinates)
-    tree = spatial.cKDTree
+    tree = spatial.KDTree
     try:
         from sklearn.neighbors import KDTree, BallTree
 

--- a/pointpats/geometry.py
+++ b/pointpats/geometry.py
@@ -42,7 +42,7 @@ def area(shape):
 
 
 @area.register
-def _(shape: spatial.qhull.ConvexHull):
+def _(shape: spatial.ConvexHull):
     """
     If a shape is a convex hull from scipy,
     assure it's 2-dimensional and then use its volume.
@@ -85,7 +85,7 @@ def _(shape: numpy.ndarray):
 
 
 @bbox.register
-def _(shape: spatial.qhull.ConvexHull):
+def _(shape: spatial.ConvexHull):
     """
     For scipy.spatial.ConvexHulls, compute the bounding box from
     their boundary points.
@@ -132,7 +132,7 @@ def _(shape: spatial.Delaunay, x: float, y: float):
 
 
 @contains.register
-def _(shape: spatial.qhull.ConvexHull, x: float, y: float):
+def _(shape: spatial.ConvexHull, x: float, y: float):
     """
     For convex hulls, convert their exterior first into a Delaunay triangulation
     and then use the delaunay dispatcher.
@@ -174,7 +174,7 @@ def _(shape: numpy.ndarray):
 
 
 @centroid.register
-def _(shape: spatial.qhull.ConvexHull):
+def _(shape: spatial.ConvexHull):
     """
     Treat convex hulls as arrays of points
     """
@@ -403,7 +403,7 @@ def prepare_hull(coordinates, hull=None):
         - an (N,2) array of points for which the bounding box will be computed & used
         - a shapely polygon/multipolygon
         - a shapely geometry
-        - a scipy.spatial.qhull.ConvexHull
+        - a scipy.spatial.ConvexHull
     """
     if isinstance(hull, numpy.ndarray):
         assert len(hull) == 4, f"bounding box provided is not shaped correctly! {hull}"
@@ -422,7 +422,7 @@ def prepare_hull(coordinates, hull=None):
             return spatial.ConvexHull(coordinates)
         elif hull.startswith("alpha") or hull.startswith("α"):
             return alpha_shape_auto(coordinates)
-    elif isinstance(hull, spatial.qhull.ConvexHull):
+    elif isinstance(hull, spatial.ConvexHull):
         return hull
     raise ValueError(
         f"Hull type {hull} not in the set of valid options:"

--- a/pointpats/tests/test_ripley.py
+++ b/pointpats/tests/test_ripley.py
@@ -23,7 +23,7 @@ points = numpy.asarray(
     ]
 )
 
-tree = spatial.cKDTree(points)
+tree = spatial.KDTree(points)
 
 chull = spatial.ConvexHull(points)
 ashape = alpha_shape_auto(points)

--- a/pointpats/tests/test_spacetime.py
+++ b/pointpats/tests/test_spacetime.py
@@ -10,9 +10,9 @@ class SpaceTimeEvents_Tester(unittest.TestCase):
 
     def test_SpaceTimeEvents(self):
         events = SpaceTimeEvents(self.path, "T")
-        self.assertEquals(events.n, 188)
-        self.assertEquals(list(events.space[0]), [300.0, 302.0])
-        self.assertEquals(list(events.t[0]), [413])
+        self.assertEqual(events.n, 188)
+        self.assertEqual(list(events.space[0]), [300.0, 302.0])
+        self.assertEqual(list(events.t[0]), [413])
 
 
 class Knox_Tester(unittest.TestCase):
@@ -22,7 +22,7 @@ class Knox_Tester(unittest.TestCase):
 
     def test_knox(self):
         result = knox(self.events.space, self.events.t, delta=20, tau=5, permutations=1)
-        self.assertEquals(result["stat"], 13.0)
+        self.assertEqual(result["stat"], 13.0)
 
 
 class Mantel_Tester(unittest.TestCase):
@@ -40,7 +40,7 @@ class Mantel_Tester(unittest.TestCase):
             tcon=0.0,
             tpow=1.0,
         )
-        self.assertAlmostEquals(result["stat"], 0.014154, 6)
+        self.assertAlmostEqual(result["stat"], 0.014154, 6)
 
 
 class Jacquez_Tester(unittest.TestCase):
@@ -49,9 +49,9 @@ class Jacquez_Tester(unittest.TestCase):
         self.events = SpaceTimeEvents(path, "T")
 
     def test_jacquez(self):
-        result = jacquez(self.events.space,
-                self.events.t, k=3, permutations=1)
-        self.assertEquals(result['stat'], 12)
+        result = jacquez(self.events.space, self.events.t, k=3, permutations=1)
+        self.assertEqual(result["stat"], 12)
+
 
 class ModifiedKnox_Tester(unittest.TestCase):
     def setUp(self):
@@ -62,7 +62,7 @@ class ModifiedKnox_Tester(unittest.TestCase):
         result = modified_knox(
             self.events.space, self.events.t, delta=20, tau=5, permutations=1
         )
-        self.assertAlmostEquals(result["stat"], 2.810160, 6)
+        self.assertAlmostEqual(result["stat"], 2.810160, 6)
 
 
 suite = unittest.TestSuite()


### PR DESCRIPTION
Follow up on #91 reported in #89.

- removing direct invocation of `scipy.spatial.cKDtree` which will be deprecated (use `scipy.spatial.KDtree` instead)
- fixing ConvexHull namespace
- fixing pytest deprecations