### PR TITLE
ENH: return axis when plotting QStatistic, default to equal aspect when plotting PointPattern

### DIFF
--- a/pointpats/pointpattern.py
+++ b/pointpats/pointpattern.py
@@ -203,14 +203,17 @@ class PointPattern(object):
             for part in self.window.parts:
                 p = Polygon(np.asarray(part))
                 patches.append(p)
-            ax.add_collection(PatchCollection(patches, facecolor='w',
-                              edgecolor='k', alpha=0.3))
+            ax.add_collection(
+                PatchCollection(patches, facecolor="none", edgecolor="k", alpha=0.3)
+            )
         if hull:
             patches = []
             p = Polygon(self.hull)
             patches.append(p)
-            ax.add_collection(PatchCollection(patches, facecolor='w',
-                              edgecolor='k', alpha=0.3))
+            ax.add_collection(
+                PatchCollection(patches, facecolor="none", edgecolor="k", alpha=0.3)
+            )
+        ax.set_aspect("equal")
 
         # plt.plot(x, y, '.')
         if get_ax:

--- a/pointpats/quadrat_statistics.py
+++ b/pointpats/quadrat_statistics.py
@@ -156,8 +156,8 @@ class RectangleM:
                 count = dict_id_count[cell_id]
                 position_x = x_min + self.rectangle_width * (x + 0.5)
                 position_y = y_min + self.rectangle_height * (y + 0.5)
-                ax.text(position_x, position_y, str(count))
-        plt.show()
+                ax.text(position_x, position_y, str(count), ha="center", va="center")
+        return ax
 
 
 class HexagonM:
@@ -358,8 +358,8 @@ class HexagonM:
                 color=line_color_cell,
             )
 
-            ax.text(center_x, center_y, str(dict_id_count[id]))
-        plt.show()
+            ax.text(center_x, center_y, str(dict_id_count[id]), ha="center", va="center")
+        return ax
 
 
 class QStatistic:
@@ -485,4 +485,4 @@ class QStatistic:
 
         """
 
-        self.mr.plot(title=title)
+        return self.mr.plot(title=title)


### PR DESCRIPTION
Minor enhancements of our plotting code in `PointPattern` and `QStatistic`. 

`QStatistic` now returns the axis so you can do anything you want with it, e.g. add contextily basemap or any other layer. 

`PointPattern` defaults to equal aspect since it is expected that in most cases, coordinates are projected. This does not skew the geography. When they are in lat lon, assuming plate carree should also be a better option than the default ratio. In any case, since you can get `ax` now, you can change it afterwards.