### PR TITLE
plot density on axis

### DIFF
--- a/pointpats/kde.py
+++ b/pointpats/kde.py
@@ -9,6 +9,8 @@ def plot_density(
     levels=10,
     fill=False,
     margin=0.1,
+    ax=None,
+    figsize=None,
     **kwargs,
 ):
     """Plot kernel density of a given point pattern
@@ -53,6 +55,11 @@ def plot_density(
         The factor of the margin by which the extent of the data will be expanded when
         creating the grid. 0.1 means 10% on each side, by default 0.1. Only used
         with the ``statsmodels`` implementation.
+    ax : matplotlib.axes.Axes (default None)
+        axes on which to draw the plot
+    figsize : tuple of integers (default None)
+        Size of the resulting ``matplotlib.figure.Figure``. If the argument
+        ``ax`` is given explicitly, ``figsize`` is ignored.
     **kwargs
         Keyword arguments passed to :meth:`~matplotlib.pyplot.contour` or
         :meth:`~matplotlib.pyplot.contourf` used for further
@@ -62,8 +69,8 @@ def plot_density(
 
     Returns
     -------
-    matplotlib.pyplot.QuadContourSet
-        plot
+    matplotlib.axes.Axes
+        matplotlib axes instance with the contour plot
     """
     if kernel is None:
         try:
@@ -89,6 +96,11 @@ def plot_density(
         import matplotlib.pyplot as plt
     except ImportError as err:
         raise ImportError("matplotlib is required for `plot_density`") from err
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
+
+    ax.set_aspect("equal") # bandwidth is fixed, hence aspect shall be equal
 
     if isinstance(data, np.ndarray):
         pass
@@ -144,6 +156,8 @@ def plot_density(
         z = points.reshape(resolution, resolution).T
 
     if fill:
-        return plt.contourf(x_mesh, y_mesh, z, levels=levels, **kwargs)
+        ax.contourf(x_mesh, y_mesh, z, levels=levels, **kwargs)
     else:
-        return plt.contour(x_mesh, y_mesh, z, levels=levels, **kwargs)
+        ax.contour(x_mesh, y_mesh, z, levels=levels, **kwargs)
+
+    return ax

--- a/pointpats/tests/test_kde.py
+++ b/pointpats/tests/test_kde.py
@@ -28,71 +28,76 @@ class TestDensity:
         )
 
     def test_default(self):
-        qm = plot_density(self.points, 10)
-        collections = list(qm.collections)
-        assert len(collections) == 12
-        for col in collections:
-            assert col.get_linewidths() == np.array(1.5)
+        ax = plot_density(self.points, 10)
+        contourset = ax.collections[0]
+        assert len(contourset.collections) == 12
+        assert not contourset.filled
+        np.testing.assert_array_equal(contourset.get_linewidths(), np.array([1.5] * 12))
         np.testing.assert_array_equal(
-            collections[5].get_edgecolor(),
-            np.array([[0.143343, 0.522773, 0.556295, 1.0]]),
+            contourset.get_edgecolor()[5],
+            np.array([0.143343, 0.522773, 0.556295, 1.0]),
         )
 
     def test_bandwidth(self):
-        qm = plot_density(self.points, 1)
-        collections = list(qm.collections)
-        assert len(collections) == 10
+        ax = plot_density(self.points, 1)
+        contourset = ax.collections[0]
+        assert len(contourset.collections) == 10
 
     def test_resolution(self):
-        qm = plot_density(self.points, 10, resolution=200)
-        collections = list(qm.collections)
+        ax = plot_density(self.points, 10, resolution=200)
+        contourset = ax.collections[0]
+        collections = contourset.collections
         assert len(collections) == 12
 
     def test_margin(self):
-        qm = plot_density(self.points, 10, margin=.3)
-        collections = list(qm.collections)
+        ax = plot_density(self.points, 10, margin=0.3)
+        contourset = ax.collections[0]
+        collections = contourset.collections
         assert len(collections) == 12
 
     def test_kdepy(self):
-        qm = plot_density(self.points, 10, kernel="gaussian")
-        collections = list(qm.collections)
+        ax = plot_density(self.points, 10, kernel="gaussian")
+        contourset = ax.collections[0]
+        collections = contourset.collections
         assert len(collections) == 12
-        for col in collections:
-            assert col.get_linewidths() == np.array(1.5)
+        np.testing.assert_array_equal(contourset.get_linewidths(), np.array([1.5] * 12))
 
     def test_levels(self):
-        qm = plot_density(self.points, 10, levels=5)
-        collections = list(qm.collections)
+        ax = plot_density(self.points, 10, levels=5)
+        contourset = ax.collections[0]
+        collections = contourset.collections
         assert len(collections) == 7
 
     def test_fill(self):
-        qm = plot_density(self.points, 10, fill=True)
-        collections = list(qm.collections)
-        assert collections[0].get_edgecolor().shape == (0, 4)
+        ax = plot_density(self.points, 10, fill=True)
+        contourset = ax.collections[0]
+        assert contourset.get_edgecolor().shape == (0, 4)
+        assert contourset.filled
         np.testing.assert_array_equal(
-            collections[0].get_facecolor(),
-            np.array([[0.279566, 0.067836, 0.391917, 1.0]]),
+            contourset.get_facecolor()[0],
+            np.array([0.279566, 0.067836, 0.391917, 1.0]),
         )
 
     def test_geopandas(self):
         geopandas = pytest.importorskip("geopandas")
 
         gs = geopandas.GeoSeries.from_xy(*self.points.T)
-        qm = plot_density(gs, 10)
-        collections = list(qm.collections)
+        ax = plot_density(gs, 10)
+        contourset = ax.collections[0]
+        collections = contourset.collections
         assert len(collections) == 12
-        for col in collections:
-            assert col.get_linewidths() == np.array(1.5)
+        np.testing.assert_array_equal(contourset.get_linewidths(), np.array([1.5] * 12))
 
     def test_kwargs(self):
-        qm = plot_density(
+        ax = plot_density(
             self.points, 10, cmap="magma", linewidths=0.5, linestyles="-."
         )
-        collections = list(qm.collections)
+        contourset = ax.collections[0]
+        collections = contourset.collections
         assert len(collections) == 12
-        for col in collections:
-            assert col.get_linewidths() == np.array(0.5)
+        np.testing.assert_array_equal(contourset.get_linewidths(), np.array([0.5] * 12))
+
         np.testing.assert_array_equal(
-            collections[5].get_edgecolor(),
-            np.array([[0.639216, 0.189921, 0.49415, 1.0]]),
+            contourset.get_edgecolor()[5],
+            np.array([0.639216, 0.189921, 0.49415, 1.0]),
         )


### PR DESCRIPTION
> right now this gives back a `matplotlib.contour.QuadContourSet`. Is there any way to have it return an axes object, e.g. to play nicely with contextily? (https://github.com/pysal/pointpats/pull/118#issuecomment-1734643715)

Yep.