### PR TITLE
REF: reimplement mrr on top of shapely

### DIFF
--- a/ci/envs/310-latest.yaml
+++ b/ci/envs/310-latest.yaml
@@ -8,7 +8,6 @@ dependencies:
   - pandas
   - matplotlib
   - libpysal
-  - py-opencv
   # tests
   - scikit-learn
   - shapely
@@ -19,5 +18,4 @@ dependencies:
   - codecov
   - pip
   - pip:
-      - opencv-contrib-python
       - KDEpy

--- a/ci/envs/311-dev.yaml
+++ b/ci/envs/311-dev.yaml
@@ -9,7 +9,6 @@ dependencies:
   - libpysal
   - mapclassify
   - folium
-  - py-opencv
   # tests
   - shapely
   - pyproj
@@ -20,7 +19,6 @@ dependencies:
   - pip
   - pip:
       - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
-      - opencv-contrib-python
       - git+https://github.com/geopandas/geopandas.git
       - git+https://github.com/pysal/libpysal.git
       - scipy

--- a/ci/envs/311-latest.yaml
+++ b/ci/envs/311-latest.yaml
@@ -8,7 +8,6 @@ dependencies:
   - pandas
   - matplotlib
   - libpysal
-  - py-opencv
   # tests
   - scikit-learn
   - shapely
@@ -19,7 +18,6 @@ dependencies:
   - codecov
   - pip
   - pip:
-      - opencv-contrib-python
       - KDEpy
   # for docs build action (this env only)
   - nbsphinx

--- a/ci/envs/38-minimal.yaml
+++ b/ci/envs/38-minimal.yaml
@@ -8,7 +8,6 @@ dependencies:
   - pandas=1.3
   - matplotlib=3.4
   - libpysal=4.5
-  - py-opencv=4.6
   # tests
   - scikit-learn==1.2
   - shapely
@@ -16,6 +15,3 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-  - pip
-  - pip:
-      - opencv-contrib-python==4.6.0.66

--- a/ci/envs/39-latest.yaml
+++ b/ci/envs/39-latest.yaml
@@ -8,7 +8,6 @@ dependencies:
   - pandas
   - matplotlib
   - libpysal
-  - py-opencv
   # tests
   - scikit-learn
   - shapely
@@ -19,5 +18,4 @@ dependencies:
   - codecov
   - pip
   - pip:
-      - opencv-contrib-python
       - KDEpy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -287,7 +287,6 @@ intersphinx_mapping = {"python": ('https://docs.python.org/3', None),
                        'libpysal': ('https://pysal.org/libpysal/', None),
                        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
                        'matplotlib':("https://matplotlib.org/", None),
-                       'opencv-contrib-python':("https://docs.opencv.org/3.4/index.html", None),
                        'KDEpy':("https://kdepy.readthedocs.io/en/latest/", None),
                        'statsmodels':("https://www.statsmodels.org/stable/", None),
                        }

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -83,8 +83,7 @@ def minimum_rotated_rectangle(points, return_angle=False):
     Compute the minimum rotated rectangle for an input point set.
 
     This is the smallest enclosing rectangle (possibly rotated)
-    for the input point set. It is computed using OpenCV2, so
-    if that is not available, then this function will fail.
+    for the input point set. It is computed using Shapely.
 
     Parameters
     ----------
@@ -94,7 +93,6 @@ def minimum_rotated_rectangle(points, return_angle=False):
     return_angle : bool
         whether to return the angle (in degrees) of the angle between
         the horizontal axis of the rectanle and the first side (i.e. length).
-        Computed directly from cv2.minAreaRect.
 
     Returns
     -------
@@ -386,8 +384,22 @@ def _skyum_lists(points):
     removed = []
     i = 0
     while True:
-        angles = [_angle(_prec(p, points), p, _succ(p, points),) for p in points]
-        circles = [_circle(_prec(p, points), p, _succ(p, points),) for p in points]
+        angles = [
+            _angle(
+                _prec(p, points),
+                p,
+                _succ(p, points),
+            )
+            for p in points
+        ]
+        circles = [
+            _circle(
+                _prec(p, points),
+                p,
+                _succ(p, points),
+            )
+            for p in points
+        ]
         radii = [c[0] for c in circles]
         lexord = np.lexsort((radii, angles))  # confusing as hell defaults...
         lexmax = lexord[-1]
@@ -514,14 +526,14 @@ def _circle(p, q, r, dmetric=_euclidean_distance):
     else:
         D = 2 * (px * (qy - ry) + qx * (ry - py) + rx * (py - qy))
         center_x = (
-            (px ** 2 + py ** 2) * (qy - ry)
-            + (qx ** 2 + qy ** 2) * (ry - py)
-            + (rx ** 2 + ry ** 2) * (py - qy)
+            (px**2 + py**2) * (qy - ry)
+            + (qx**2 + qy**2) * (ry - py)
+            + (rx**2 + ry**2) * (py - qy)
         ) / float(D)
         center_y = (
-            (px ** 2 + py ** 2) * (rx - qx)
-            + (qx ** 2 + qy ** 2) * (px - rx)
-            + (rx ** 2 + ry ** 2) * (qx - px)
+            (px**2 + py**2) * (rx - qx)
+            + (qx**2 + qy**2) * (px - rx)
+            + (rx**2 + ry**2) * (qx - px)
         ) / float(D)
         radius = _euclidean_distance(center_x, center_y, px, py)
     return radius, center_x, center_y

--- a/pointpats/tests/test_centrography.py
+++ b/pointpats/tests/test_centrography.py
@@ -1,6 +1,8 @@
 # TODO: skyum, dtot, weighted_mean_center, manhattan_median
 import unittest
 import numpy as np
+import shapely
+import pytest
 
 from ..centrography import *
 
@@ -26,6 +28,10 @@ class TestCentrography(unittest.TestCase):
             ]
         )
 
+    @pytest.mark.skipif(
+            shapely.geos_version < (3, 12, 0),
+            reason="Requires GEOS 3.12.0 to use correct algorithm"
+    )
     def test_centrography_mar(self):
         mrr = minimum_rotated_rectangle(self.points)
         known = np.array(


### PR DESCRIPTION
Resolves the issue seen in https://github.com/pysal/libpysal/issues/681 where opencv causes installation headache. Since we already depend on shapely, there's no need to depend on OpenCV, so using shapely's minimum_rotated_rectangle, computing the angle manually and coercing the resulting array into the opencv-like order (which is the opposite compared to shapely).