### PR TITLE
ENH: support geopandas objects in distance statistics

### DIFF
--- a/pointpats/distance_statistics.py
+++ b/pointpats/distance_statistics.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 import geopandas
 import numpy
+import shapely
 from scipy import interpolate, spatial
 
 from .geometry import (
@@ -60,7 +61,7 @@ def _prepare(coordinates, support, distances, metric, hull, edge_correction):
         raise NotImplementedError("Edge correction is not currently implemented.")
 
     if isinstance(coordinates, geopandas.GeoDataFrame | geopandas.GeoSeries):
-        coordinates = coordinates.get_coordinates().values
+        coordinates = shapely.get_coordinates(coordinates.geometry)
 
     # cast to coordinate array
     if isinstance(coordinates, TREE_TYPES):
@@ -555,7 +556,7 @@ def _ripley_test(
     **kwargs,
 ):
     if isinstance(coordinates, geopandas.GeoDataFrame | geopandas.GeoSeries):
-        coordinates = coordinates.get_coordinates().values
+        coordinates = shapely.get_coordinates(coordinates.geometry)
 
     stat_function, result_container = _ripley_dispatch.get(calltype)
     core_kwargs = dict(

--- a/pointpats/distance_statistics.py
+++ b/pointpats/distance_statistics.py
@@ -1,16 +1,26 @@
-import numpy
 import warnings
-from scipy import spatial, interpolate
 from collections import namedtuple
+
+import geopandas
+import numpy
+from scipy import interpolate, spatial
+
 from .geometry import (
-    area as _area,
-    k_neighbors as _k_neighbors,
-    build_best_tree as _build_best_tree,
-    prepare_hull as _prepare_hull,
     TREE_TYPES,
 )
+from .geometry import (
+    area as _area,
+)
+from .geometry import (
+    build_best_tree as _build_best_tree,
+)
+from .geometry import (
+    k_neighbors as _k_neighbors,
+)
+from .geometry import (
+    prepare_hull as _prepare_hull,
+)
 from .random import poisson
-
 
 __all__ = [
     "f",
@@ -48,6 +58,9 @@ def _prepare(coordinates, support, distances, metric, hull, edge_correction):
     # Throw early if edge correction is requested
     if edge_correction is not None:
         raise NotImplementedError("Edge correction is not currently implemented.")
+
+    if isinstance(coordinates, geopandas.GeoDataFrame | geopandas.GeoSeries):
+        coordinates = coordinates.get_coordinates().values
 
     # cast to coordinate array
     if isinstance(coordinates, TREE_TYPES):
@@ -127,7 +140,7 @@ def f(
 
     Parameters
     ----------
-    coordinates : numpy.ndarray of shape (n,2)
+    coordinates : geopandas object | numpy.ndarray of shape (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)
@@ -211,7 +224,7 @@ def g(
 
     Parameters
     -----------
-    coordinates : numpy.ndarray of shape (n,2)
+    coordinates : geopandas object | numpy.ndarray of shape (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)
@@ -301,7 +314,7 @@ def j(
 
     Parameters
     -----------
-    coordinates : numpy.ndarray, (n,2)
+    coordinates : geopandas object | numpy.ndarray, (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)
@@ -390,7 +403,7 @@ def k(
     This function counts the number of pairs of points that are closer than a given distance.
     As d increases, K approaches the number of point pairs.
 
-    coordinates : numpy.ndarray, (n,2)
+    coordinates : geopandas object | numpy.ndarray, (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)
@@ -459,7 +472,7 @@ def l(
 
     Parameters
     ----------
-    coordinates : numpy.ndarray, (n,2)
+    coordinates : geopandas object | numpy.ndarray, (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)
@@ -541,6 +554,9 @@ def _ripley_test(
     n_simulations=9999,
     **kwargs,
 ):
+    if isinstance(coordinates, geopandas.GeoDataFrame | geopandas.GeoSeries):
+        coordinates = coordinates.get_coordinates().values
+
     stat_function, result_container = _ripley_dispatch.get(calltype)
     core_kwargs = dict(
         support=support,
@@ -621,7 +637,7 @@ def f_test(
 
     Parameters
     -----------
-    coordinates : numpy.ndarray, (n,2)
+    coordinates : geopandas object | numpy.ndarray, (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)
@@ -686,7 +702,7 @@ def g_test(
 
     Parameters
     ----------
-    coordinates : numpy.ndarray, (n,2)
+    coordinates : geopandas object | numpy.ndarray, (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)
@@ -749,7 +765,7 @@ def j_test(
     When the J function is consistently below 1, then it indicates clustering.
     When consistently above 1, it suggests dispersion.
 
-    coordinates : numpy.ndarray, (n,2)
+    coordinates : geopandas object | numpy.ndarray, (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)
@@ -828,7 +844,7 @@ def k_test(
 
     Parameters
     ----------
-    coordinates : numpy.ndarray, (n,2)
+    coordinates : geopandas object | numpy.ndarray, (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)
@@ -894,7 +910,7 @@ def l_test(
 
     Parameters
     ----------
-    coordinates : numpy.ndarray, (n,2)
+    coordinates : geopandas object | numpy.ndarray, (n,2)
         input coordinates to function
     support : tuple of length 1, 2, or 3, int, or numpy.ndarray
         tuple, encoding (stop,), (start, stop), or (start, stop, num)

--- a/pointpats/tests/test_distance_statistics.py
+++ b/pointpats/tests/test_distance_statistics.py
@@ -4,7 +4,9 @@ from pointpats import distance_statistics as ripley, geometry, random
 from libpysal.cg import alpha_shape_auto
 import shapely
 import warnings
+import geopandas
 import pytest
+
 
 points = numpy.asarray(
     [
@@ -22,6 +24,8 @@ points = numpy.asarray(
         [54.46, 8.48],
     ]
 )
+
+points_gs = geopandas.GeoSeries.from_xy(*points.T)
 
 tree = spatial.KDTree(points)
 
@@ -207,8 +211,8 @@ def test_simulate():
     # cluster poisson
     # cluster normal
 
-
-def test_f():
+@pytest.mark.parametrize("points", [points, points_gs], ids=["numpy.ndarray", "GeoSeries"])
+def test_f(points):
     # -------------------------------------------------------------------------#
     # Check f function has consistent performance
 
@@ -234,8 +238,8 @@ def test_f():
     )
     assert f_test.simulations.shape == (99, 15)
 
-
-def test_g():
+@pytest.mark.parametrize("points", [points, points_gs], ids=["numpy.ndarray", "GeoSeries"])
+def test_g(points):
     # -------------------------------------------------------------------------#
     # Check f function works, has statistical results that are consistent
 
@@ -257,8 +261,8 @@ def test_g():
     )
     assert g_test.simulations.shape == (99, 15)
 
-
-def test_j():
+@pytest.mark.parametrize("points", [points, points_gs], ids=["numpy.ndarray", "GeoSeries"])
+def test_j(points):
     # -------------------------------------------------------------------------#
     # Check j function works, matches manual, is truncated correctly
 
@@ -282,8 +286,8 @@ def test_j():
 
     numpy.testing.assert_allclose(j_test.statistic, manual_j[:4], atol=0.1, rtol=0.05)
 
-
-def test_k():
+@pytest.mark.parametrize("points", [points, points_gs], ids=["numpy.ndarray", "GeoSeries"])
+def test_k(points):
     # -------------------------------------------------------------------------#
     # Check K function works, matches a manual, slower explicit computation
 
@@ -297,8 +301,8 @@ def test_k():
         k_test.statistic, manual_unscaled_k * 2 / n / intensity
     )
 
-
-def test_l():
+@pytest.mark.parametrize("points", [points, points_gs], ids=["numpy.array", "GeoSeries"])
+def test_l(points):
     # -------------------------------------------------------------------------#
     # Check L Function works, can be linearized, and has the right value
     _, k = ripley.k(points, support=support)


### PR DESCRIPTION
A simple change that allows us to pass geopandas objects directly onto Ripley's functions without a need of extracting the underlying array of coordinates.

This is a part of #135 that does not need me to learn the dispatch thingy :)