### PR TITLE
ENH: singledispatch in centrography to natively support geopandas objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ __pycache__
 
 doc/_build
 doc/generated
+
+docs/_build
+docs/generated

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -36,6 +36,8 @@ Centrography
    :toctree: generated/
 
     minimum_bounding_rectangle
+    minimum_bounding_circle
+    minimum_rotated_rectangle
     hull
     mean_center
     weighted_mean_center
@@ -43,7 +45,6 @@ Centrography
     std_distance
     euclidean_median
     ellipse
-    skyum
     dtot
 
 

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -17,6 +17,7 @@ __all__ = [
     "ellipse",
     "minimum_rotated_rectangle",
     "minimum_bounding_rectangle",
+    "minimum_bounding_circle",
     "dtot",
     "_circle",
 ]

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -1,9 +1,6 @@
 """
 Centrographic measures for point patterns
 
-TODO
-
-- testing
 - documentation
 
 """
@@ -494,7 +491,7 @@ def minimum_bounding_circle(points):
 
     Returns
     -------
-    (x,y),center for the minimum bounding circle.
+    (x,y),radius for the minimum bounding circle.
     """
     try:
         points = np.asarray(points)

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -52,18 +52,47 @@ def minimum_bounding_rectangle(points):
     Parameters
     ----------
     points : arraylike
-             (n,2), (x,y) coordinates of a series of event points.
+             array representing a point pattern
 
     Returns
     -------
-    min_x  : float
-             leftmost value of the vertices of minimum bounding rectangle.
-    min_y  : float
-             downmost value of the vertices of minimum bounding rectangle.
-    max_x  : float
-             rightmost value of the vertices of minimum bounding rectangle.
-    max_y  : float
-             upmost value of the vertices of minimum bounding rectangle.
+    rectangle
+        minimum bounding rectangle of a given point pattern
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...         [54.46, 8.48],
+    ...     ]
+    ... )
+
+    Passing an array of coordinates returns a tuple capturing the bounds.
+
+    >>> minimum_bounding_rectangle(coords)
+    (np.float64(8.23), np.float64(7.68), np.float64(98.73), np.float64(92.08))
+
+    Passing a GeoPandas object returns a shapely geometry.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> minimum_bounding_rectangle(geoms)
+    <POLYGON ((8.23 7.68, 98.73 7.68, 98.73 92.08, 8.23 92.08, 8.23 7.68))>
 
     """
     try:
@@ -94,27 +123,71 @@ def _(points: GeoPandasBase) -> shapely.Polygon:
 @singledispatch
 def minimum_rotated_rectangle(points, return_angle=False):
     """
-    Compute the minimum rotated rectangle for an input point set.
+    Compute the minimum rotated rectangle for a point array.
 
     This is the smallest enclosing rectangle (possibly rotated)
     for the input point set. It is computed using Shapely.
 
     Parameters
     ----------
-    points : numpy.ndarray
-        A numpy array of shape (n_observations, 2) containing the point
-        locations to compute the rotated rectangle
+    points : arraylike
+             array representing a point pattern
     return_angle : bool
         whether to return the angle (in degrees) of the angle between
         the horizontal axis of the rectanle and the first side (i.e. length).
 
     Returns
     -------
-    an numpy.ndarray of shape (4, 2) containing the coordinates
-    of the minimum rotated rectangle. If return_angle is True,
-    also return the angle (in degrees) of the rotated rectangle.
+    rectangle | tuple(rectangle, angle)
 
-    """
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...         [54.46, 8.48],
+    ...     ]
+    ... )
+
+
+    Passing an array of coordinates returns an array capturing the corners.
+
+    >>> minimum_rotated_rectangle(coords)
+    array([[107.91345156,  73.47376296],
+       [ 36.40164577, 104.61744544],
+       [  4.08727852,  30.41752523],
+       [ 75.5990843 ,  -0.72615725]])
+
+    >>> minimum_rotated_rectangle(coords, return_angle=True)
+    (array([[107.91345156,  73.47376296],
+            [ 36.40164577, 104.61744544],
+            [  4.08727852,  30.41752523],
+            [ 75.5990843 ,  -0.72615725]]), 66.46667861350298)
+
+    Passing a GeoPandas object returns a shapely geometry.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> minimum_rotated_rectangle(geoms)
+    <POLYGON ((75.599 -0.7, 4.087 30.418, 36.402 104.617, 107.913 73.474, 75.599...>
+
+    >>> minimum_rotated_rectangle(geoms, return_angle=True)
+    (<POLYGON ((75.599 -0.7, 4.087 30.418, 36.402 104.617, 107.913 73.474, 75.599...>, 66.46667861350298)
+    """  # noqa: E501
     try:
         points = np.asarray(points)
         return minimum_rotated_rectangle(points, return_angle=return_angle)
@@ -166,13 +239,56 @@ def hull(points):
 
     Parameters
     ----------
-    points: arraylike
-            (n,2), (x,y) coordinates of a series of event points.
+    points : arraylike
+             array representing a point pattern
 
     Returns
     -------
-    _     : array
-            (h,2), points defining the hull in counterclockwise order.
+    rectangle
+        convex hull of a given point pattern
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...         [54.46, 8.48],
+    ...     ]
+    ... )
+
+    Passing an array of coordinates returns an array capturing the vertices.
+
+    >>> hull(coords)
+    array([[31.01, 81.21],
+           [ 8.23, 39.93],
+           [ 9.47, 31.02],
+           [22.52, 22.39],
+           [54.46,  8.48],
+           [79.26,  7.68],
+           [89.78, 42.53],
+           [98.73, 77.17],
+           [65.19, 92.08]])
+
+    Passing a GeoPandas object returns a shapely geometry.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> hull(geoms)
+    <POLYGON ((79.26 7.68, 54.46 8.48, 22.52 22.39, 9.47 31.02, 8.23 39.93, 31.0...>
     """
     try:
         points = np.asarray(points)
@@ -199,13 +315,48 @@ def mean_center(points):
 
     Parameters
     ----------
-    points: arraylike
-            (n,2), (x,y) coordinates of a series of event points.
+    points : arraylike
+             array representing a point pattern
 
     Returns
     -------
-    _     : array
-            (2,), (x,y) coordinates of the mean center.
+    center
+        center of a given point pattern
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...         [54.46, 8.48],
+    ...     ]
+    ... )
+
+    Passing an array of coordinates returns an array capturing the center.
+
+    >>> mean_center(coords)
+    array([52.57166667, 46.17166667])
+
+    Passing a GeoPandas object returns a shapely geometry.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> mean_center(geoms)
+    <POINT (52.572 46.172)>
     """
     try:
         points = np.asarray(points)
@@ -232,15 +383,51 @@ def weighted_mean_center(points, weights):
 
     Parameters
     ----------
-    points  : arraylike
-              (n,2), (x,y) coordinates of a series of event points.
+    points : arraylike
+        array representing a point pattern
     weights : arraylike
-              a series of attribute values of length n.
+        a series of attribute values of length n.
 
     Returns
     -------
-    _      : array
-             (2,), (x,y) coordinates of the weighted mean center.
+    center
+        center of a given point pattern
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...         [54.46, 8.48],
+    ...     ]
+    ... )
+    >>> weight = np.arange(1, 13, 1)
+
+    Passing an array of coordinates returns an array capturing the center.
+
+    >>> weighted_mean_center(coords, weight)
+    array([59.29448718, 47.52282051])
+
+    Passing a GeoPandas object returns a shapely geometry.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> weighted_mean_center(geoms, weight)
+    <POINT (59.294 47.523)>
     """
     try:
         points = np.asarray(points)
@@ -271,12 +458,46 @@ def manhattan_median(points):
     Parameters
     ----------
     points  : arraylike
-              (n,2), (x,y) coordinates of a series of event points.
+              array representing a point pattern
 
     Returns
     -------
-    _      : array
-             (2,), (x,y) coordinates of the manhattan median.
+    median
+        manhattan median of a given point pattern
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...     ]
+    ... )
+
+    Passing an array of coordinates returns an array capturing the median.
+
+    >>> manhattan_median(coords)
+    array([65.19, 42.53])
+
+    Passing a GeoPandas object returns a shapely geometry.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> manhattan_median(geoms)
+    <POINT (65.19 42.53)>
     """
     try:
         points = np.asarray(points)
@@ -301,19 +522,53 @@ def _(points: GeoPandasBase) -> shapely.Point:
 
 
 @singledispatch
-def std_distance(points) -> NDArray[np.float64]:
+def std_distance(points) -> np.float64:
     """
     Calculate standard distance of a point array.
 
     Parameters
     ----------
     points  : arraylike
-              (n,2), (x,y) coordinates of a series of event points.
+              array representing a point pattern
 
     Returns
     -------
-    _      : float
-             standard distance.
+    distance
+       standard distance of a given point pattern
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...     ]
+    ... )
+
+    Passing an array of coordinates returns a tuple capturing the bounds.
+
+    >>> std_distance(coords)
+    np.float64(40.21575987282547)
+
+    The same applies to a GeoPandas object.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> std_distance(geoms)
+    np.float64(40.21575987282547)
     """
     try:
         points = np.asarray(points)
@@ -323,14 +578,14 @@ def std_distance(points) -> NDArray[np.float64]:
 
 
 @std_distance.register
-def _(points: np.ndarray) -> NDArray[np.float64]:
+def _(points: np.ndarray) -> np.float64:
     n, _ = points.shape
     m = points.mean(axis=0)
     return np.sqrt(((points * points).sum(axis=0) / n - m * m).sum())
 
 
 @std_distance.register
-def _(points: GeoPandasBase) -> NDArray[np.float64]:
+def _(points: GeoPandasBase) -> np.float64:
     coords = shapely.get_coordinates(points.geometry)
     return std_distance(coords)
 
@@ -343,23 +598,54 @@ def ellipse(points):
     Parameters
     ----------
     points : arraylike
-             (n,2), (x,y) coordinates of a series of event points.
+             array representing a point pattern
 
     Returns
     -------
-    _      : float
-             semi-major axis.
-    _      : float
-             semi-minor axis.
-    theta  : float
-             clockwise rotation angle of the ellipse.
+    ellipse
+        representation of the standard ellipse
 
     Notes
     -----
     Implements approach from:
 
     https://www.icpsr.umich.edu/CrimeStat/files/CrimeStatChapter.4.pdf
-    """
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...     ]
+    ... )
+
+    Passing an array of coordinates returns a tuple capturing the semi-major axis,
+    semi-minor axis and clockwise rotation angle of the ellipse.
+
+    >>> ellipse(coords)
+    (np.float64(37.952226702678644), np.float64(45.55366350677291), np.float64(1.2242381172906325))
+
+    Passing a GeoPandas object returns a shapely geometry.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> ellipse(geoms)
+    <POLYGON ((65.291 85.294, 69.428 83.606, 73.402 81.59, 77.173 79.265, 80.706...>
+    """  # noqa: E501
     try:
         points = np.asarray(points)
         return ellipse(points)
@@ -405,15 +691,52 @@ def dtot(coord, points) -> float:
 
     Parameters
     ----------
-    coord   : arraylike
-              (x,y) coordinates of a point.
+    coord
+              starting point
     points  : arraylike
-              (n,2), (x,y) coordinates of a series of event points.
+              array representing a point pattern
 
     Returns
     -------
-    d       : float
-              sum of Euclidean distances.
+    distance
+        sum of Euclidean distances.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+    >>> import shapely
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...     ]
+    ... )
+
+    Passing an array of coordinates returns a tuple capturing the bounds.
+
+    >>> point = [30.78, 60.10]
+    >>> dtot(point, coords)
+    np.float64(465.3617957739617)
+
+    The same applies to a GeoPandas object.
+
+    >>> point = shapely.Point(point)
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> dtot(point, geoms)
+    np.float64(465.3617957739617)
 
     """
     try:
@@ -446,13 +769,47 @@ def euclidean_median(points):
 
     Parameters
     ----------
-    points: arraylike
-            (n,2), (x,y) coordinates of a series of event points.
+    points  : arraylike
+        array representing a point pattern
 
     Returns
     -------
-    _     : array
-            (2,), (x,y) coordinates of the Euclidean median.
+    median
+        Euclidean median of a given point pattern
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...     ]
+    ... )
+
+    Passing an array of coordinates returns an array capturing the median.
+
+    >>> euclidean_median(coords)
+    array([53.51770575, 49.6572671 ])
+
+    Passing a GeoPandas object returns a shapely geometry.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> euclidean_median(geoms)
+    <POINT (53.518 49.657)>
 
     """
     try:
@@ -491,13 +848,47 @@ def minimum_bounding_circle(points):
 
     Parameters
     ----------
-    points  :   numpy.ndarray
-        a numpy array of shape (n_observations, 2) to compute
-        the minimum bounding circle
+    points  : arraylike
+        array representing a point pattern
 
     Returns
     -------
-    (x,y),radius for the minimum bounding circle.
+    circle
+        minimum bounding circle
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import geopandas as gpd
+
+    Create an array of point coordinates.
+
+    >>> coords = np.array(
+    ...     [
+    ...         [66.22, 32.54],
+    ...         [22.52, 22.39],
+    ...         [31.01, 81.21],
+    ...         [9.47, 31.02],
+    ...         [30.78, 60.10],
+    ...         [75.21, 58.93],
+    ...         [79.26, 7.68],
+    ...         [8.23, 39.93],
+    ...         [98.73, 77.17],
+    ...         [89.78, 42.53],
+    ...         [65.19, 92.08],
+    ...     ]
+    ... )
+
+    Passing an array of coordinates returns an tuple of (x, y), radius.
+
+    >>> minimum_bounding_circle(coords)
+    ((55.244520477497474, 51.88135107645883), np.float64(50.304102155590726))
+
+    Passing a GeoPandas object returns a shapely geometry.
+
+    >>> geoms = gpd.GeoSeries.from_xy(*coords.T)
+    >>> minimum_bounding_circle(geoms)
+    <POLYGON ((105.549 51.881, 105.306 46.951, 104.582 42.068, 103.383 37.279, 1...>
     """
     try:
         points = np.asarray(points)

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -30,11 +30,11 @@ import math
 import sys
 import warnings
 from functools import singledispatch
-from typing import Union
 
 import geopandas as gpd
 import numpy as np
 import shapely
+from geopandas.base import GeoPandasBase
 from libpysal.cg import is_clockwise
 from scipy.optimize import minimize
 from scipy.spatial import ConvexHull
@@ -88,7 +88,7 @@ def _(points: np.ndarray):
 
 
 @minimum_bounding_rectangle.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+def _(points: GeoPandasBase):
     return shapely.envelope(shapely.geometrycollections(points.geometry.values))
 
 
@@ -147,7 +147,7 @@ def _(points: np.ndarray, return_angle: bool = False):
 
 
 @minimum_rotated_rectangle.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame], return_angle: bool = False):
+def _(points: GeoPandasBase, return_angle: bool = False):
     rectangle = shapely.minimum_rotated_rectangle(shapely.multipoints(points.geometry))
 
     if return_angle:
@@ -185,7 +185,7 @@ def _(points: np.ndarray):
 
 
 @hull.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+def _(points: GeoPandasBase):
     return shapely.convex_hull(shapely.multipoints(points.geometry))
 
 
@@ -217,7 +217,7 @@ def _(points: np.ndarray):
 
 
 @mean_center.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+def _(points: GeoPandasBase):
     coords = shapely.get_coordinates(points.geometry)
     return shapely.Point(mean_center(coords))
 
@@ -255,7 +255,7 @@ def _(points: np.ndarray, weights):
 
 
 @weighted_mean_center.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame], weights):
+def _(points: GeoPandasBase, weights):
     coords = shapely.get_coordinates(points.geometry)
     return shapely.Point(weighted_mean_center(coords, weights))
 
@@ -292,7 +292,7 @@ def _(points: np.ndarray):
 
 
 @manhattan_median.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+def _(points: GeoPandasBase):
     coords = shapely.get_coordinates(points.geometry)
     return shapely.Point(manhattan_median(coords))
 
@@ -327,7 +327,7 @@ def _(points: np.ndarray):
 
 
 @std_distance.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+def _(points: GeoPandasBase):
     coords = shapely.get_coordinates(points.geometry)
     return std_distance(coords)
 
@@ -386,7 +386,7 @@ def _(points: np.ndarray):
 
 
 @ellipse.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+def _(points: GeoPandasBase):
     coords = shapely.get_coordinates(points.geometry)
     return ellipse(coords)
 
@@ -426,7 +426,7 @@ def _(coord: np.ndarray, points: np.ndarray):
 
 
 @dtot.register
-def _(coord: shapely.Point, points: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+def _(coord: shapely.Point, points: GeoPandasBase):
     coord = shapely.get_coordinates(coord).flatten()
     points = shapely.get_coordinates(points.geometry)
     return dtot(coord, points)
@@ -463,7 +463,7 @@ def _(points: np.ndarray):
 
 
 @euclidean_median.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+def _(points: GeoPandasBase):
     coords = shapely.get_coordinates(points.geometry)
     return euclidean_median(coords)
 
@@ -521,7 +521,7 @@ def _(points: np.ndarray):
 
 
 @minimum_bounding_circle.register
-def _(points: Union[gpd.GeoSeries, gpd.GeoDataFrame]):
+def _(points: GeoPandasBase):
     coords = shapely.get_coordinates(points.geometry)
     (x, y), r = minimum_bounding_circle(coords)
     return shapely.Point(x, y).buffer(r)

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -388,7 +388,11 @@ def _(points: np.ndarray):
 @ellipse.register
 def _(points: GeoPandasBase):
     coords = shapely.get_coordinates(points.geometry)
-    return ellipse(coords)
+    major, minor, rotation = ellipse(coords)
+    centre = mean_center(points).buffer(1)
+    scaled = shapely.affinity.scale(centre, major, minor)
+    rotated = shapely.affinity.rotate(scaled, rotation, use_radians=True)
+    return rotated
 
 
 @singledispatch

--- a/pointpats/tests/test_centrography.py
+++ b/pointpats/tests/test_centrography.py
@@ -135,6 +135,9 @@ def test_ellipse(points):
 def test_euclidean_median(points):
     euclidean = centrography.euclidean_median(points)
     res = np.array([54.16770671, 44.4242589])
+    if isinstance(points, gpd.GeoSeries):
+        assert isinstance(euclidean, shapely.Point)
+        euclidean = shapely.get_coordinates(euclidean).flatten()
     np.testing.assert_array_almost_equal(euclidean, res, decimal=3)
 
 @dispatch_types

--- a/pointpats/tests/test_centrography.py
+++ b/pointpats/tests/test_centrography.py
@@ -116,12 +116,6 @@ def test_centrography_ellipse(points):
     if isinstance(points, gpd.GeoSeries):
         assert shapely.Point(52.571666666666836, 46.17166666666682).equals_exact(res.centroid, 1e-5)
         np.testing.assert_allclose(res.area, 5313.537950951353, RTOL)
-        assert shapely.Polygon([(75.35555380165113, -7.417558286073575),
-            (-2.5919130566989, 27.519856670878436),
-            (29.787779531682332, 99.76089161940709),
-            (107.73524639003224, 64.82347666245569),
-            (75.35555380165113, -7.417558286073575),
-            ]).equals_exact(res.oriented_envelope, 1e-5)
     else:
         np.testing.assert_allclose(res[0], 39.623867886462982, RTOL)
         np.testing.assert_allclose(res[1], 42.753818949026815, RTOL)

--- a/pointpats/tests/test_centrography.py
+++ b/pointpats/tests/test_centrography.py
@@ -33,7 +33,7 @@ dispatch_types = pytest.mark.parametrize("points", [points, geoms, sequence], id
         reason="Requires GEOS 3.12.0 to use correct algorithm"
 )
 @dispatch_types
-def test_centrography_mar(points):
+def test_minimum_rotated_rectangle(points):
     mrr = centrography.minimum_rotated_rectangle(points)
     known = np.array(
         [
@@ -57,8 +57,18 @@ def test_centrography_mar(points):
                 f"\ncomputed {mrr}\nknown: {known}"
             )
 
+@pytest.mark.skipif(
+        shapely.geos_version < (3, 12, 0),
+        reason="Requires GEOS 3.12.0 to use correct algorithm"
+)
 @dispatch_types
-def test_centrography_mbr(points):
+def test_minimum_rotated_rectangle_angle(points):
+    _, angle = centrography.minimum_rotated_rectangle(points, return_angle=True)
+    np.testing.assert_allclose(angle, 66.46667861350298, RTOL)
+
+
+@dispatch_types
+def test_minimum_bounding_rectangle(points):
     res = centrography.minimum_bounding_rectangle(points)
     if isinstance(points, gpd.GeoSeries):
         assert shapely.box(
@@ -75,7 +85,7 @@ def test_centrography_mbr(points):
         np.testing.assert_allclose(max_y, 92.079999999999998, RTOL)
 
 @dispatch_types
-def test_centrography_hull(points):
+def test_hull(points):
     hull = centrography.hull(points)
     exp = np.array(
         [
@@ -96,7 +106,7 @@ def test_centrography_hull(points):
         np.testing.assert_array_equal(hull, exp)
 
 @dispatch_types
-def test_centrography_mean_center(points):
+def test_mean_center(points):
     exp = np.array([52.57166667, 46.17166667])
     res = centrography.mean_center(points)
     if isinstance(points, gpd.GeoSeries):
@@ -106,12 +116,12 @@ def test_centrography_mean_center(points):
         np.testing.assert_array_almost_equal(res, exp)
 
 @dispatch_types
-def test_centrography_std_distance(points):
+def test_std_distance(points):
     std = centrography.std_distance(points)
     np.testing.assert_allclose(std, 40.149806489086714, RTOL)
 
 @dispatch_types
-def test_centrography_ellipse(points):
+def test_ellipse(points):
     res = centrography.ellipse(points)
     if isinstance(points, gpd.GeoSeries):
         assert shapely.Point(52.571666666666836, 46.17166666666682).equals_exact(res.centroid, 1e-5)
@@ -122,7 +132,50 @@ def test_centrography_ellipse(points):
         np.testing.assert_allclose(res[2], 1.1039268428650906, RTOL)
 
 @dispatch_types
-def test_centrography_euclidean_median(points):
+def test_euclidean_median(points):
     euclidean = centrography.euclidean_median(points)
     res = np.array([54.16770671, 44.4242589])
     np.testing.assert_array_almost_equal(euclidean, res, decimal=3)
+
+@dispatch_types
+def test_minimum_bounding_circle(points):
+    res = centrography.minimum_bounding_circle(points)
+    x = 55.244520477497474
+    y = 51.88135107645883
+    r = 50.304102155590726
+    if isinstance(points, gpd.GeoSeries):
+        assert shapely.Point(x, y).equals_exact(res.centroid, 1e-5)
+        np.testing.assert_allclose(np.sqrt(res.area /np.pi), r, 0.1)
+    else:
+        np.testing.assert_allclose(res[0][0], x, RTOL)
+        np.testing.assert_allclose(res[0][1], y, RTOL)
+        np.testing.assert_allclose(res[1], r, RTOL)
+
+@dispatch_types
+def test_weighted_mean_center(points):
+    res = centrography.weighted_mean_center(points, np.tile(np.array([1, 2, 3]), 4))
+    exp = np.array([53.18333333333333, 50.83916666666667])
+    if isinstance(points, gpd.GeoSeries):
+        exp = shapely.Point(exp)
+        assert exp.equals_exact(res, 1e-5)
+    else:
+        np.testing.assert_array_almost_equal(res, exp)
+
+@dispatch_types
+def test_manhattan_median(points):
+    with pytest.warns(UserWarning, match="Manhattan Median is not unique for even"):
+        res = centrography.manhattan_median(points)
+    exp = np.array([59.825, 41.230])
+    if isinstance(points, gpd.GeoSeries):
+        exp = shapely.Point(exp)
+        assert exp.equals_exact(res, 1e-5)
+    else:
+        np.testing.assert_array_almost_equal(res, exp)
+
+@dispatch_types
+def test_dtot(points):
+    coord = [20, 30]
+    if isinstance(points, gpd.GeoSeries):
+        coord = shapely.Point(*coord)
+    res = centrography.dtot(coord, points)
+    np.testing.assert_allclose(res, 570.3801950846755, RTOL)

--- a/pointpats/tests/test_centrography.py
+++ b/pointpats/tests/test_centrography.py
@@ -1,47 +1,51 @@
-# TODO: skyum, dtot, weighted_mean_center, manhattan_median
-import unittest
 import numpy as np
 import shapely
 import pytest
+import geopandas as gpd
 
-from ..centrography import *
+from pointpats import centrography
 
 from libpysal.common import RTOL
 
+points = np.array(
+    [
+        [66.22, 32.54],
+        [22.52, 22.39],
+        [31.01, 81.21],
+        [9.47, 31.02],
+        [30.78, 60.10],
+        [75.21, 58.93],
+        [79.26, 7.68],
+        [8.23, 39.93],
+        [98.73, 77.17],
+        [89.78, 42.53],
+        [65.19, 92.08],
+        [54.46, 8.48],
+    ]
+)
+geoms =  gpd.GeoSeries.from_xy(*points.T)
+sequence = points.tolist()
 
-class TestCentrography(unittest.TestCase):
-    def setUp(self):
-        self.points = np.array(
-            [
-                [66.22, 32.54],
-                [22.52, 22.39],
-                [31.01, 81.21],
-                [9.47, 31.02],
-                [30.78, 60.10],
-                [75.21, 58.93],
-                [79.26, 7.68],
-                [8.23, 39.93],
-                [98.73, 77.17],
-                [89.78, 42.53],
-                [65.19, 92.08],
-                [54.46, 8.48],
-            ]
-        )
+dispatch_types = pytest.mark.parametrize("points", [points, geoms, sequence], ids=["ndarray", "geoseries", "list"])
 
-    @pytest.mark.skipif(
-            shapely.geos_version < (3, 12, 0),
-            reason="Requires GEOS 3.12.0 to use correct algorithm"
+@pytest.mark.skipif(
+        shapely.geos_version < (3, 12, 0),
+        reason="Requires GEOS 3.12.0 to use correct algorithm"
+)
+@dispatch_types
+def test_centrography_mar(points):
+    mrr = centrography.minimum_rotated_rectangle(points)
+    known = np.array(
+        [
+            [36.40165, 104.61744],
+            [4.087286, 30.417522],
+            [75.59908, -0.726158],
+            [107.913445, 73.47376251220703],
+        ]
     )
-    def test_centrography_mar(self):
-        mrr = minimum_rotated_rectangle(self.points)
-        known = np.array(
-            [
-                [36.40165, 104.61744],
-                [4.087286, 30.417522],
-                [75.59908, -0.726158],
-                [107.913445, 73.47376251220703],
-            ]
-        )
+    if isinstance(points, gpd.GeoSeries):
+        assert shapely.Polygon(known).normalize().equals_exact(mrr.normalize(), 1e-5)
+    else:
         for i in range(5):
             success = np.allclose(mrr, np.roll(known, i, axis=0))
             if success:
@@ -53,45 +57,78 @@ class TestCentrography(unittest.TestCase):
                 f"\ncomputed {mrr}\nknown: {known}"
             )
 
-    def test_centrography_mbr(self):
-        min_x, min_y, max_x, max_y = minimum_bounding_rectangle(self.points)
+@dispatch_types
+def test_centrography_mbr(points):
+    res = centrography.minimum_bounding_rectangle(points)
+    if isinstance(points, gpd.GeoSeries):
+        assert shapely.box(
+            8.2300000000000004,
+            7.6799999999999997,
+            98.730000000000004,
+            92.079999999999998
+            ).normalize().equals_exact(res.normalize(), 1e-5)
+    else:
+        min_x, min_y, max_x, max_y = res
         np.testing.assert_allclose(min_x, 8.2300000000000004, RTOL)
         np.testing.assert_allclose(min_y, 7.6799999999999997, RTOL)
         np.testing.assert_allclose(max_x, 98.730000000000004, RTOL)
         np.testing.assert_allclose(max_y, 92.079999999999998, RTOL)
 
-    def test_centrography_hull(self):
-        hull_array = hull(self.points)
-        res = np.array(
-            [
-                [31.01, 81.21],
-                [8.23, 39.93],
-                [9.47, 31.02],
-                [22.52, 22.39],
-                [54.46, 8.48],
-                [79.26, 7.68],
-                [89.78, 42.53],
-                [98.73, 77.17],
-                [65.19, 92.08],
-            ]
-        )
-        np.testing.assert_array_equal(hull_array, res)
+@dispatch_types
+def test_centrography_hull(points):
+    hull = centrography.hull(points)
+    exp = np.array(
+        [
+            [31.01, 81.21],
+            [8.23, 39.93],
+            [9.47, 31.02],
+            [22.52, 22.39],
+            [54.46, 8.48],
+            [79.26, 7.68],
+            [89.78, 42.53],
+            [98.73, 77.17],
+            [65.19, 92.08],
+        ]
+    )
+    if isinstance(points, gpd.GeoSeries):
+        assert shapely.Polygon(exp).normalize().equals_exact(hull.normalize(), 1e-5)
+    else:
+        np.testing.assert_array_equal(hull, exp)
 
-    def test_centrography_mean_center(self):
-        res = np.array([52.57166667, 46.17166667])
-        np.testing.assert_array_almost_equal(mean_center(self.points), res)
+@dispatch_types
+def test_centrography_mean_center(points):
+    exp = np.array([52.57166667, 46.17166667])
+    res = centrography.mean_center(points)
+    if isinstance(points, gpd.GeoSeries):
+        exp = shapely.Point(exp)
+        assert exp.equals_exact(res, 1e-5)
+    else:
+        np.testing.assert_array_almost_equal(res, exp)
 
-    def test_centrography_std_distance(self):
-        std = std_distance(self.points)
-        np.testing.assert_allclose(std, 40.149806489086714, RTOL)
+@dispatch_types
+def test_centrography_std_distance(points):
+    std = centrography.std_distance(points)
+    np.testing.assert_allclose(std, 40.149806489086714, RTOL)
 
-    def test_centrography_ellipse(self):
-        res = ellipse(self.points)
+@dispatch_types
+def test_centrography_ellipse(points):
+    res = centrography.ellipse(points)
+    if isinstance(points, gpd.GeoSeries):
+        assert shapely.Point(52.571666666666836, 46.17166666666682).equals_exact(res.centroid, 1e-5)
+        np.testing.assert_allclose(res.area, 5313.537950951353, RTOL)
+        assert shapely.Polygon([(75.35555380165113, -7.417558286073575),
+            (-2.5919130566989, 27.519856670878436),
+            (29.787779531682332, 99.76089161940709),
+            (107.73524639003224, 64.82347666245569),
+            (75.35555380165113, -7.417558286073575),
+            ]).equals_exact(res.oriented_envelope, 1e-5)
+    else:
         np.testing.assert_allclose(res[0], 39.623867886462982, RTOL)
         np.testing.assert_allclose(res[1], 42.753818949026815, RTOL)
         np.testing.assert_allclose(res[2], 1.1039268428650906, RTOL)
 
-    def test_centrography_euclidean_median(self):
-        euclidean = euclidean_median(self.points)
-        res = np.array([54.16770671, 44.4242589])
-        np.testing.assert_array_almost_equal(euclidean, res, decimal=3)
+@dispatch_types
+def test_centrography_euclidean_median(points):
+    euclidean = centrography.euclidean_median(points)
+    res = np.array([54.16770671, 44.4242589])
+    np.testing.assert_array_almost_equal(euclidean, res, decimal=3)


### PR DESCRIPTION
~Very much WIP as I just wanted to see how this actually works. Will continue at some point later on this.~

One thing I wanted to figure out was to ensure that we also support numpy arrays of shapely objects and return a shapely object but it seems that singledispatch typing is a bit limited in this sense and there's no way of distinguishing between `np.ndarray[np.float64]` and `np.ndarray[shapely.Geometry]`. At least none of the attempts I made worked.

xref #135 

TODO:

- [x] complete test suite
- [x] update docstrings