### PR TITLE
Address SyntaxWarning warning upon import

### DIFF
--- a/pointpats/pointpattern.py
+++ b/pointpats/pointpattern.py
@@ -283,7 +283,7 @@ class PointPattern(object):
         .. math::
 
             \\lambda(s_j) = \\lim \\limits_{|\\mathbf{A}s_j|
-            \\to 0} \\left \\{ \\frac{E(Y(\mathbf{A}s_j)}{|\mathbf{A}s_j|}
+            \\to 0} \\left \\{ \\frac{E(Y(\\mathbf{A}s_j)}{|\\mathbf{A}s_j|}
             \\right \\}
 
         where :math:`\\mathbf{A}s_j` is a small region surrounding location

--- a/pointpats/process.py
+++ b/pointpats/process.py
@@ -158,7 +158,7 @@ class PointProcess(object):
 class PoissonPointProcess(PointProcess):
     """
     Poisson point process including :math:`N`-conditioned CSR process and
-    :math:`\lambda`-conditioned CSR process.
+    :math:`\\lambda`-conditioned CSR process.
 
     Parameters
     ----------
@@ -170,7 +170,7 @@ class PoissonPointProcess(PointProcess):
     samples       : list
                     Number of realizations.
     conditioning  : bool
-                    If True, use the :math:`\lambda`-conditioned CSR process,
+                    If True, use the :math:`\\lambda`-conditioned CSR process,
                     number of events would vary across realizations;
                     if False, use the :math:`N`-conditioned CSR process.
     asPP          : bool
@@ -235,7 +235,7 @@ class PoissonPointProcess(PointProcess):
            [-76.33475868,  36.62635347],
            [-79.71621808,  37.27396618]])
 
-    2. Simulate a :math:`\lambda`-conditioned csr process in the same window (10
+    2. Simulate a :math:`\\lambda`-conditioned csr process in the same window (10
     points, 2 realizations)
 
     >>> np.random.seed(5)
@@ -297,8 +297,8 @@ class PoissonClusterPointProcess(PointProcess):
     Poisson cluster point process (Neyman Scott).
     Two stages:
     1. parent CSR process: :math:`N`-conditioned or
-    :math:`\lambda`-conditioned. If parent events follow a
-    :math:`\lambda`-conditioned CSR process,
+    :math:`\\lambda`-conditioned. If parent events follow a
+    :math:`\\lambda`-conditioned CSR process,
     the number of parent events varies across realizations.
     2. child process: fixed number of points in circle centered
     on each parent.
@@ -388,7 +388,7 @@ class PoissonClusterPointProcess(PointProcess):
 
     2. Simulate a Poisson cluster process of size 200 with 10 parents
     and 20 children within 0.5 units of each parent
-    (parent events:  :math:`\lambda`-conditioned CSR)
+    (parent events:  :math:`\\lambda`-conditioned CSR)
 
     >>> np.random.seed(10)
     >>> samples2 = PoissonClusterPointProcess(window, 200, 10, 0.5, 1, asPP=True, conditioning=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ docs = [
 tests = [
     "codecov",
     "coverage",
+    "folium",
+    "mapclassify",
     "pytest",
     "pytest-mpl",
     "pytest-cov",


### PR DESCRIPTION
Following #153 this PR:
- Adds the missing escape. (fixes #153)
- Adds the missing deps for test.

While the `SyntaxWarning` is gone, there are still some other warnings
when running `pytest`:

```console
micromamba/envs/ts/lib/python3.13/site-packages/geopandas/_compat.py:7: DeprecationWarning: The 'shapely.geos' module is deprecated, and will be removed in a future version. All attributes of 'shapely.geos' are available directly from the top-level 'shapely' namespace (since shapely 2.0.0).
    import shapely.geos

pointpats/tests/test_distance_statistics.py:33
  repos/pointpats/pointpats/tests/test_distance_statistics.py:33: UserWarning: Numba not imported, so alpha shape construction may be slower than expected.
    ashape = alpha_shape_auto(points)

pointpats/tests/test_distance_statistics.py::test_prepare
pointpats/tests/test_distance_statistics.py::test_prepare
  repos/pointpats/pointpats/geometry.py:424: UserWarning: Numba not imported, so alpha shape construction may be slower than expected.
    return alpha_shape_auto(coordinates)

pointpats/tests/test_distance_statistics.py::test_j[numpy.ndarray]
pointpats/tests/test_distance_statistics.py::test_j[GeoSeries]
  repos/pointpats/pointpats/tests/test_distance_statistics.py:270: UserWarning: requested [  0.           7.14285714  14.28571429  21.42857143  28.57142857
    35.71428571  42.85714286  50.          57.14285714  64.28571429
    71.42857143  78.57142857  85.71428571  92.85714286 100.        ] bins to evaluate the J function, but it reaches infinity at d=100.0000, meaning only 15 bins will be used to characterize the J function.
    j_test = ripley.j_test(points, support=support, n_simulations=99, truncate=True)

pointpats/tests/test_pointpattern.py: 28 warnings
pointpats/tests/test_quadrat_statistics.py: 3 warnings
  repos/pointpats/pointpats/window.py:23: FutureWarning: Objects based on the `Geometry` class will deprecated and removed in a future version of libpysal.
    return ps.cg.shapes.Polygon(c)

pointpats/tests/test_pointpattern.py: 28 warnings
pointpats/tests/test_quadrat_statistics.py: 3 warnings
  micromamba/envs/ts/lib/python3.13/site-packages/libpysal/cg/shapes.py:1408: FutureWarning: Objects based on the `Geometry` class will deprecated and removed in a future version of libpysal.
    self._part_rings = [Ring(vertices)]

pointpats/tests/test_pointpattern.py: 28 warnings
pointpats/tests/test_quadrat_statistics.py: 3 warnings
  repos/pointpats/pointpats/window.py:76: FutureWarning: Objects based on the `Geometry` class will deprecated and removed in a future version of libpysal.
    super(Window, self).__init__(parts)

pointpats/tests/test_pointpattern.py: 28 warnings
pointpats/tests/test_quadrat_statistics.py: 3 warnings
  micromamba/envs/ts/lib/python3.13/site-packages/libpysal/cg/shapes.py:1405: FutureWarning: Objects based on the `Geometry` class will deprecated and removed in a future version of libpysal.
    self._part_rings = list(map(Ring, vertices))

pointpats/tests/test_spacetime.py::TestKnox::test_knox_from_gdf
  repos/pointpats/pointpats/spacetime.py:1595: UserWarning: There is no CRS set on the dataframe. The KDTree will assume coordinates are stored in Euclidean distances
    warn(

pointpats/tests/test_spacetime.py::TestKnox::test_knox_from_gdf
  micromamba/envs/ts/lib/python3.13/site-packages/pandas/core/generic.py:6313: DeprecationWarning: Overriding the CRS of a GeoDataFrame that already has CRS. This unsafe behavior will be deprecated in future versions. Use GeoDataFrame.set_crs method instead
    return object.__setattr__(self, name, value)

pointpats/tests/test_spacetime.py::TestKnox::test_knox_from_gdf
  repos/pointpats/pointpats/tests/test_spacetime.py:81: UserWarning: successfully caught crs error
    warn("successfully caught crs error")

pointpats/tests/test_spacetime.py::TestKnox::test_knox_from_gdf
  repos/pointpats/pointpats/tests/test_spacetime.py:89: UserWarning: successfully caught dtype error
    warn("successfully caught dtype error")

pointpats/tests/test_spacetime.py::TestKnoxLocal::test_explore
  repos/pointpats/pointpats/spacetime.py:1546: UserWarning: empty neighbor set.
    warn("empty neighbor set.")

pointpats/tests/test_spacetime.py::TestKnoxLocal::test_explore
  repos/pointpats/pointpats/spacetime.py:1549: UserWarning: The GeoSeries you are attempting to plot is composed of empty geometries. Nothing has been displayed.
    m = g[g.color == colors["focal"]].explore(

pointpats/tests/test_spacetime.py::TestKnoxLocal::test_explore
  repos/pointpats/pointpats/spacetime.py:1557: FutureWarning: <class 'geopandas.array.GeometryArray'>._reduce will require a `keepdims` parameter in the future
    ghs = ghs.dropna()

pointpats/tests/test_spacetime.py::TestKnoxLocal::test_explore
  micromamba/envs/ts/lib/python3.13/site-packages/geopandas/geoseries.py:958: UserWarning: The GeoSeries you are attempting to plot is composed of empty geometries. Nothing has been displayed.
    return _explore_geoseries(self, *args, **kwargs)

pointpats/tests/test_spacetime.py::TestSpaceTimeEvents::test_space_time_events
pointpats/tests/test_spacetime.py::TestSpaceTimeEvents::test_knox
pointpats/tests/test_spacetime.py::TestSpaceTimeEvents::test_mantel
pointpats/tests/test_spacetime.py::TestSpaceTimeEvents::test_jacquez
pointpats/tests/test_spacetime.py::TestSpaceTimeEvents::test_modified_knox
  micromamba/envs/ts/lib/python3.13/site-packages/libpysal/io/iohandlers/pyShpIO.py:209: FutureWarning: Objects based on the `Geometry` class will deprecated and removed in a future version of libpysal.
    shp = self.type((rec["X"], rec["Y"]))

pointpats/tests/test_spacetime.py::TestSpaceTimeEvents::test_knox
  repos/pointpats/pointpats/tests/test_spacetime.py:383: DeprecationWarning: This function is deprecated. Use Knox
    result = knox(self.events.space, self.events.t, delta=20, tau=5, permutations=1)

pointpats/tests/test_spacetime.py::TestSpaceTimeEvents::test_jacquez
  micromamba/envs/ts/lib/python3.13/site-packages/libpysal/weights/distance.py:153: UserWarning: The weights matrix is not fully connected:
   There are 13 disconnected components.
    W.__init__(self, neighbors, id_order=ids, **kwargs)

pointpats/tests/test_spacetime.py::TestSpaceTimeEvents::test_jacquez
  micromamba/envs/ts/lib/python3.13/site-packages/libpysal/weights/distance.py:153: UserWarning: The weights matrix is not fully connected:
   There are 3 disconnected components.
    W.__init__(self, neighbors, id_order=ids, **kwargs)
```
