### PR TITLE
remove deprecated `numpy.row_stack` for `numpy.vstack`

### DIFF
--- a/pointpats/random.py
+++ b/pointpats/random.py
@@ -382,8 +382,8 @@ def cluster_poisson(
                 hull=hull,
                 rng=rng,
             )
-            clusters[i_cluster] = numpy.row_stack((seed, candidates))
-        result[i_replication] = numpy.row_stack(clusters)
+            clusters[i_cluster] = numpy.vstack((seed, candidates))
+        result[i_replication] = numpy.vstack(clusters)
     return result.squeeze()
 
 
@@ -463,8 +463,8 @@ def cluster_normal(hull, cov=None, size=None, n_seeds=2, rng=None):
                 size=n_in_cluster - 1,
                 rng=candidate_seeds[i_cluster],
             )
-            clusters[i_cluster] = numpy.row_stack((center, candidates))
-        result[i_replication] = numpy.row_stack(clusters)
+            clusters[i_cluster] = numpy.vstack((center, candidates))
+        result[i_replication] = numpy.vstack(clusters)
     return result.squeeze()
 
 


### PR DESCRIPTION
* remove deprecated `numpy.row_stack()` for `numpy.vstack()`
* this gets us down to 70 warning in tests; all but 1 ([#189](https://github.com/pysal/pointpats/issues/189)) are warning for PySAL geometries



```
DeprecationWarning: `row_stack` alias is deprecated. Use `np.vstack` directly.
```