### PR TITLE
fix skyums algorithm

### DIFF
--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -1031,7 +1031,7 @@ def _skyum_lists(points):
             for p in points
         ]
         radii = [c[0] for c in circles]
-        lexord = np.lexsort((angles, radii))  # confusing as hell defaults...
+        lexord = np.lexsort((angles, radii))
         lexmax = lexord[-1]
         candidate = (
             _prec(points[lexmax], points),
@@ -1080,9 +1080,7 @@ try:
         # workaround for no lexsort in numba
         radius_argmax = radii.argmax()
         radius_max = radii[radius_argmax]
-        # angle_argmax = angles.argmax()
-        # angle_max = angles[angle_argmax]
-        # the maximum radius for the largest angle
+        # the maximum angle for the largest radius
         lexmax = (angles * (radii == radius_max)).argmax()
 
         if angles[lexmax] <= (np.pi / 2.0):

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -917,7 +917,7 @@ def _(points: GeoPandasBase) -> shapely.Point:
 
 
 @singledispatch
-def minimum_bounding_circle(points):
+def minimum_bounding_circle(points, **buffer_kw):
     """
     Implements Skyum (1990)'s algorithm for the minimum bounding circle in R^2.
 
@@ -934,6 +934,9 @@ def minimum_bounding_circle(points):
     ----------
     points  : arraylike
         array representing a point pattern
+    buffer_kw : dict
+        arguments passed to shapely.buffer() to construct an output geometry.
+        Ignored if the input is not a geopandas.GeoSeries.
 
     Returns
     -------
@@ -982,7 +985,7 @@ def minimum_bounding_circle(points):
 
 
 @minimum_bounding_circle.register
-def _(points: np.ndarray) -> tuple[tuple[float, float], float]:
+def _(points: np.ndarray, **buffer_kw) -> tuple[tuple[float, float], float]:
     try:
         from numba import njit  # noqa: F401 `numba.njit` imported but unused
 
@@ -1003,10 +1006,10 @@ def _(points: np.ndarray) -> tuple[tuple[float, float], float]:
 
 
 @minimum_bounding_circle.register
-def _(points: GeoPandasBase) -> shapely.Polygon:
+def _(points: GeoPandasBase, **buffer_kw) -> shapely.Polygon:
     coords = shapely.get_coordinates(points.geometry)
     (x, y), r = minimum_bounding_circle(coords)
-    return shapely.Point(x, y).buffer(r)
+    return shapely.Point(x, y).buffer(r, **buffer_kw)
 
 
 def _skyum_lists(points):

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -1031,7 +1031,7 @@ def _skyum_lists(points):
             for p in points
         ]
         radii = [c[0] for c in circles]
-        lexord = np.lexsort((radii, angles))  # confusing as hell defaults...
+        lexord = np.lexsort((angles, radii))  # confusing as hell defaults...
         lexmax = lexord[-1]
         candidate = (
             _prec(points[lexmax], points),
@@ -1078,10 +1078,12 @@ try:
             circles[i] = _circle(p, q, r)
         radii = circles[:, 0]
         # workaround for no lexsort in numba
-        angle_argmax = angles.argmax()
-        angle_max = angles[angle_argmax]
+        radius_argmax = radii.argmax()
+        radius_max = radii[radius_argmax]
+        # angle_argmax = angles.argmax()
+        # angle_max = angles[angle_argmax]
         # the maximum radius for the largest angle
-        lexmax = (radii * (angles == angle_max)).argmax()
+        lexmax = (angles * (radii == radius_max)).argmax()
 
         if angles[lexmax] <= (np.pi / 2.0):
             return True, points, lexmax, circles[lexmax]

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -994,7 +994,7 @@ def _(points: np.ndarray) -> tuple[tuple[float, float], float]:
         points = points[::-1]
         if not_clockwise(points):
             raise Exception("Points are neither clockwise nor counterclockwise")
-    _points = copy.deepcopy(points)
+    _points = copy.deepcopy(points).astype(float)
     if has_numba:  # noqa: SIM108
         circ = _skyum_numba(_points)[0]
     else:

--- a/pointpats/centrography.py
+++ b/pointpats/centrography.py
@@ -975,7 +975,7 @@ def minimum_bounding_circle(points):
     <POLYGON ((105.549 51.881, 105.306 46.951, 104.582 42.068, 103.383 37.279, 1...>
     """
     try:
-        points = np.asarray(points)
+        points = np.asarray(points).astype(float)
         return minimum_bounding_circle(points)
     except AttributeError as e:
         raise NotImplementedError from e

--- a/pointpats/tests/test_centrography.py
+++ b/pointpats/tests/test_centrography.py
@@ -113,7 +113,6 @@ def test_euclidean_median(points):
 @dispatch_types
 def test_minimum_bounding_circle(points):
     res = centrography.minimum_bounding_circle(points)
-    n, _ = points.shape
     x = 2.7
     y = 2.7
     r = 1.8384776310850237
@@ -129,7 +128,7 @@ def test_minimum_bounding_circle(points):
         np.testing.assert_allclose(res[0][0], x, RTOL)
         np.testing.assert_allclose(res[0][1], y, RTOL)
         np.testing.assert_allclose(res[1], r, RTOL)
-    d = numpy.sqrt(((np.array([x_, y_]) - points) ** 2).sum(axis=1))
+    d = np.sqrt(((np.array([x_, y_]) - points) ** 2).sum(axis=1))
     assert (d <= r).all(), "some point is not within the minimum bounding circle!"
 
 

--- a/pointpats/tests/test_centrography.py
+++ b/pointpats/tests/test_centrography.py
@@ -112,7 +112,7 @@ def test_euclidean_median(points):
 
 @dispatch_types
 def test_minimum_bounding_circle(points):
-    res = centrography.minimum_bounding_circle(points)
+    res = centrography.minimum_bounding_circle(points, quad_segs=150)
     x = 2.7
     y = 2.7
     r = 1.8384776310850237
@@ -122,14 +122,30 @@ def test_minimum_bounding_circle(points):
         y_ = res.centroid.y
         r_ = np.sqrt(res.area / np.pi)
         assert shapely.Point(x, y).equals_exact(res.centroid, 1e-5)
-        np.testing.assert_allclose(np.sqrt(res.area / np.pi), r, 0.1)
+        np.testing.assert_allclose(
+            np.sqrt(res.area / np.pi),
+            r,
+            0.001,
+            err_msg="recovered radius is not within .1% of real radius",
+        )
+        d = np.sqrt(
+            ((np.array([x_, y_]) - points.get_coordinates().values) ** 2).sum(axis=1)
+        )
+        np.testing.assert_allclose(
+            d.max(),
+            r,
+            0.001,
+            err_msg="constructed circle does not approximately contain all points.",
+        )
     else:
         (x_, y_), r_ = res
         np.testing.assert_allclose(res[0][0], x, RTOL)
         np.testing.assert_allclose(res[0][1], y, RTOL)
         np.testing.assert_allclose(res[1], r, RTOL)
-    d = np.sqrt(((np.array([x_, y_]) - points) ** 2).sum(axis=1))
-    assert (d <= r).all(), "some point is not within the minimum bounding circle!"
+        d = np.sqrt(((np.array([x_, y_]) - points) ** 2).sum(axis=1))
+        assert d.max() <= r, (
+            "a point is further from the circle center than the radius."
+        )
 
 
 @dispatch_types

--- a/pointpats/tests/test_centrography.py
+++ b/pointpats/tests/test_centrography.py
@@ -113,16 +113,24 @@ def test_euclidean_median(points):
 @dispatch_types
 def test_minimum_bounding_circle(points):
     res = centrography.minimum_bounding_circle(points)
-    x = 2.642857142857143
-    y = 2.7857142857142856
-    r = 1.821078397711709
+    n, _ = points.shape
+    x = 2.7
+    y = 2.7
+    r = 1.8384776310850237
     if isinstance(points, gpd.GeoSeries):
+        # lower accuracy here due to construction of circle
+        x_ = res.centroid.x
+        y_ = res.centroid.y
+        r_ = np.sqrt(res.area / np.pi)
         assert shapely.Point(x, y).equals_exact(res.centroid, 1e-5)
         np.testing.assert_allclose(np.sqrt(res.area / np.pi), r, 0.1)
     else:
+        (x_, y_), r_ = res
         np.testing.assert_allclose(res[0][0], x, RTOL)
         np.testing.assert_allclose(res[0][1], y, RTOL)
         np.testing.assert_allclose(res[1], r, RTOL)
+    d = numpy.sqrt(((np.array([x_, y_]) - points) ** 2).sum(axis=1))
+    assert (d <= r).all(), "some point is not within the minimum bounding circle!"
 
 
 @dispatch_types


### PR DESCRIPTION
As I understood it when implementing it, the minimum bounding circle in Skyum's algorithm is found by removing boundary points on the convex hull. Specifically, we start with the largest circle formed by adjacent triples and remove the middle of the triple when it subtends an obtuse angle, recalculate angles/radii for the left and right part of the triple, and continue. A similar strategy focused on *acute triples* leads to my pointset paring algorithm in #155. 

It has been a while since I read the original article, but given my comment about "confusing as hell defaults", I think #75 stems from what "lexicographic order" means in the algorithm: 

<img width="625" height="526" alt="Screenshot 2026-04-28 at 09 34 57" src="https://github.com/user-attachments/assets/5fd2a34d-15d4-4317-9e42-2a8eafb7bee5" />

I remember finding this confusing at the time---what is meant by "lexicographic" over the two keys? Do we sort first by angle, then radius? or radius, then angle? 

Eleven years ago, I ordered them in the way they appear in the paper. However, as #75 notes, this can lead to cases where the radii of the MBC is too small when the termination criteria is hit on the angle. 

**Rereading the original paper**, I think the proof for Lemma 2 implies a sort on radius, then angle: 

<img width="633" height="375" alt="Screenshot 2026-04-28 at 09 38 59" src="https://github.com/user-attachments/assets/7b0135b0-0a4d-481c-92f2-6676cd319ed6" />

the only way `radius(a,b,c)` is certainly maximal in this case is if we sort on *radius first*. When this is done, we're picking the largest radius triple that subtends an acute angle. In the case of tied radii/circle size, we pick the largest acute circle. This is guaranteed to contain the input points, so the MBC won't be sometimes too small anymore. 

```python
import geopandas as gpd
import numpy as np
import matplotlib.pyplot as plt
import shapely
from pointpats.centrography import minimum_bounding_circle as skyum

points = np.array([(1, 2), (2, 3), (2, 2), (2, 1), (3, 4), (3, 3), (3, 1), (4, 4)]).astype(float)
geoms = gpd.GeoSeries.from_xy(*points.T)

# skyum outcome
(x,y), r = skyum(points) 

ax = geoms.plot(figsize=(12, 12))
gpd.GeoSeries([shapely.Point(x, y).buffer(r)]).boundary.plot(ax=ax, color='r', linewidth=1)
geoms.to_frame().dissolve().minimum_bounding_circle().boundary.plot(ax=ax, color='g', linewidth=1)
plt.show()
```
<img width="1200" height="1200" alt="download" src="https://github.com/user-attachments/assets/1ce56dfc-398d-405e-be6d-2482c4ae37ab" />
