### PR TITLE
Sobol & Halton Generators

### DIFF
--- a/pointpats/random.py
+++ b/pointpats/random.py
@@ -709,18 +709,72 @@ def sobol(
         scramble=True,
         seed=None):
     """
-    todo
+    Simulate a point pattern using a Sobol low-discrepancy sequence.
+
+    Parameters
+    ----------
+    hull : A geometry-like object
+        This encodes the "space" in which to simulate the pattern.
+        All points will lie within this hull. Supported values are:
+
+        - a bounding box encoded as ``numpy.array([xmin, ymin, xmax, ymax])``
+        - an (N,2) array of points for which the bounding box will be computed & used
+        - a shapely polygon/multipolygon
+        - a scipy convex hull
+
+    intensity : float
+        The number of observations per unit area in the hull to use. If
+        provided, then ``size`` must be an integer describing the number of
+        replications to generate.
+
+    size : tuple or int
+        A tuple of ``(n_observations, n_replications)``, where the first
+        number is the number of points to simulate in each replication and
+        the second number is the number of replications. If an integer is
+        provided and ``intensity`` is None, one replication is generated.
+        If an integer is provided and ``intensity`` is also supplied, the
+        integer specifies the number of replications and the number of
+        observations is computed from the intensity.
+
+    scramble : bool, default True
+        If True, apply Owen scrambling to the Sobol sequence. Scrambling
+        preserves the low-discrepancy properties while allowing independent
+        realizations to be generated using different seeds.
+
+    seed : int or None, optional
+        Seed used to initialize the scrambled Sobol sequence. Ignored when
+        ``scramble=False``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Either an ``(n_replications, n_observations, 2)`` array or an
+        ``(n_observations, 2)`` array containing the simulated realizations.
+
+    Examples
+    --------
+    Generate 100 Sobol points in the unit square.
+
+    >>> points = sobol([0, 0, 1, 1], size=100, seed=123)
+    >>> points.shape
+    (100, 2)
+
+    Generate 3 independent replications.
+
+    >>> points = sobol([0, 0, 1, 1], size=(100, 3), seed=123)
+    >>> points.shape
+    (3, 100, 2)
     """
     if isinstance(hull, numpy.ndarray):
         hull = hull if hull.shape == (4,) else _prepare_hull(hull)
-    
+
     n_observations, n_simulations, intensity = parse_size_and_intensity(
         hull, intensity=intensity, size=size
     )
 
     result = numpy.empty((n_simulations, n_observations, 2))
 
-    bbox = _bbox
+    bbox = _bbox(hull)
 
     for i_replication in range(n_simulations):
         sbl = qmc.Sobol(
@@ -732,7 +786,7 @@ def sobol(
         accepted = []
 
         while len(accepted) < n_observations:
-            
+
             remaining = n_observations - len(accepted)
 
             m = int(numpy.ceil(numpy.log2(max(remaining, 1))))
@@ -741,14 +795,14 @@ def sobol(
             xs = bbox[0] + candidates[:, 0] * (bbox[2] - bbox[0])
             ys = bbox[1] + candidates[:, 1] * (bbox[3] - bbox[1])
 
-            for x, y in zip(xs, ys):
+            for x, y in zip(xs, ys, strict=True):
                 if _contains(hull, x, y):
                     accepted.append((x, y))
                 if len(accepted) == n_observations:
                     break
-        
+
         result[i_replication] = numpy.asarray(accepted)
-    
+
     return result.squeeze()
 
 def halton(
@@ -758,18 +812,72 @@ def halton(
         scramble=True,
         seed=None):
     """
-    todo
+    Simulate a point pattern using a Halton low-discrepancy sequence.
+
+    Parameters
+    ----------
+    hull : A geometry-like object
+        This encodes the "space" in which to simulate the pattern.
+        All points will lie within this hull. Supported values are:
+
+        - a bounding box encoded as ``numpy.array([xmin, ymin, xmax, ymax])``
+        - an (N,2) array of points for which the bounding box will be computed & used
+        - a shapely polygon/multipolygon
+        - a scipy convex hull
+
+    intensity : float
+        The number of observations per unit area in the hull to use. If
+        provided, then ``size`` must be an integer describing the number of
+        replications to generate.
+
+    size : tuple or int
+        A tuple of ``(n_observations, n_replications)``, where the first
+        number is the number of points to simulate in each replication and
+        the second number is the number of replications. If an integer is
+        provided and ``intensity`` is None, one replication is generated.
+        If an integer is provided and ``intensity`` is also supplied, the
+        integer specifies the number of replications and the number of
+        observations is computed from the intensity.
+
+    scramble : bool, default True
+        If True, apply scrambling to the Halton sequence. Scrambling reduces
+        correlation artifacts and allows independent realizations to be
+        generated using different seeds.
+
+    seed : int or None, optional
+        Seed used to initialize the scrambled Halton sequence. Ignored when
+        ``scramble=False``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Either an ``(n_replications, n_observations, 2)`` array or an
+        ``(n_observations, 2)`` array containing the simulated realizations.
+
+    Examples
+    --------
+    Generate 100 Halton points in the unit square.
+
+    >>> points = halton([0, 0, 1, 1], size=100, seed=123)
+    >>> points.shape
+    (100, 2)
+
+    Generate 3 independent replications.
+
+    >>> points = halton([0, 0, 1, 1], size=(100, 3), seed=123)
+    >>> points.shape
+    (3, 100, 2)
     """
     if isinstance(hull, numpy.ndarray):
         hull = hull if hull.shape == (4,) else _prepare_hull(hull)
-    
+
     n_observations, n_simulations, intensity = parse_size_and_intensity(
         hull, intensity=intensity, size=size
     )
 
     result = numpy.empty((n_simulations, n_observations, 2))
 
-    bbox = _bbox
+    bbox = _bbox(hull)
 
     for i_replication in range(n_simulations):
         hltn = qmc.Halton(
@@ -777,7 +885,7 @@ def halton(
             scramble=scramble,
             seed=None if seed is None else seed + i_replication,
         )
-    
+
     accepted = []
 
     while len(accepted) < n_observations:
@@ -789,7 +897,7 @@ def halton(
         xs = bbox[0] + candidates[:, 0] * (bbox[2] - bbox[0])
         ys = bbox[1] + candidates[:, 1] * (bbox[3] - bbox[1])
 
-        for x, y in zip(xs, ys):
+        for x, y in zip(xs, ys, strict=True):
             if _contains(hull, x, y):
                 accepted.append((x, y))
 

--- a/pointpats/random.py
+++ b/pointpats/random.py
@@ -703,12 +703,7 @@ def strauss(
     return result.squeeze()
 
 
-def sobol(
-        hull,
-        intensity=None,
-        size=None,
-        scramble=True,
-        seed=None):
+def sobol(hull, intensity=None, size=None, scramble=True, seed=None):
     """
     Simulate a point pattern using a Sobol low-discrepancy sequence.
 
@@ -787,7 +782,6 @@ def sobol(
         accepted = []
 
         while len(accepted) < n_observations:
-
             remaining = n_observations - len(accepted)
 
             m = int(numpy.ceil(numpy.log2(max(remaining, 1))))
@@ -807,12 +801,7 @@ def sobol(
     return result.squeeze()
 
 
-def halton(
-        hull,
-        intensity=None,
-        size=None,
-        scramble=True,
-        seed=None):
+def halton(hull, intensity=None, size=None, scramble=True, seed=None):
     """
     Simulate a point pattern using a Halton low-discrepancy sequence.
 
@@ -891,7 +880,6 @@ def halton(
         accepted = []
 
         while len(accepted) < n_observations:
-
             remaining = n_observations - len(accepted)
 
             candidates = hltn.random(remaining)
@@ -983,7 +971,7 @@ def r2(hull, intensity=None, size=None, seed=None):
 
         while len(accepted) < n_observations:
             remaining = n_observations - len(accepted)
-            
+
             indices = numpy.arange(n_generated + 1, n_generated + remaining + 1)
             candidates = (offset + numpy.outer(indices, alpha)) % 1.0
             n_generated += remaining

--- a/pointpats/random.py
+++ b/pointpats/random.py
@@ -25,6 +25,7 @@ spatial hulls and containment logic.
 
 import numpy
 from scipy.spatial import cKDTree
+from scipy.stats import qmc
 
 from .geometry import area as _area
 from .geometry import bbox as _bbox
@@ -698,5 +699,100 @@ def strauss(
                 "values of gamma and radius. Try reducing `intensity` or increasing "
                 "`gamma`, `radius`, or `max_iter`."
             )
+
+    return result.squeeze()
+
+def sobol(
+        hull,
+        intensity=None,
+        size=None,
+        scramble=True,
+        seed=None):
+    """
+    todo
+    """
+    if isinstance(hull, numpy.ndarray):
+        hull = hull if hull.shape == (4,) else _prepare_hull(hull)
+    
+    n_observations, n_simulations, intensity = parse_size_and_intensity(
+        hull, intensity=intensity, size=size
+    )
+
+    result = numpy.empty((n_simulations, n_observations, 2))
+
+    bbox = _bbox
+
+    for i_replication in range(n_simulations):
+        sbl = qmc.Sobol(
+            d=2,
+            scramble=scramble,
+            seed=None if seed is None else seed + i_replication,
+        )
+
+        accepted = []
+
+        while len(accepted) < n_observations:
+            
+            remaining = n_observations - len(accepted)
+
+            m = int(numpy.ceil(numpy.log2(max(remaining, 1))))
+            candidates = sbl.random_base2(m=m)
+
+            xs = bbox[0] + candidates[:, 0] * (bbox[2] - bbox[0])
+            ys = bbox[1] + candidates[:, 1] * (bbox[3] - bbox[1])
+
+            for x, y in zip(xs, ys):
+                if _contains(hull, x, y):
+                    accepted.append((x, y))
+                if len(accepted) == n_observations:
+                    break
+        
+        result[i_replication] = numpy.asarray(accepted)
+    
+    return result.squeeze()
+
+def halton(
+        hull,
+        intensity=None,
+        size=None,
+        scramble=True,
+        seed=None):
+    """
+    todo
+    """
+    if isinstance(hull, numpy.ndarray):
+        hull = hull if hull.shape == (4,) else _prepare_hull(hull)
+    
+    n_observations, n_simulations, intensity = parse_size_and_intensity(
+        hull, intensity=intensity, size=size
+    )
+
+    result = numpy.empty((n_simulations, n_observations, 2))
+
+    bbox = _bbox
+
+    for i_replication in range(n_simulations):
+        hltn = qmc.Halton(
+            d=2,
+            scramble=scramble,
+            seed=None if seed is None else seed + i_replication,
+        )
+    
+    accepted = []
+
+    while len(accepted) < n_observations:
+
+        remaining = n_observations - len(accepted)
+
+        candidates = hltn.random(remaining)
+
+        xs = bbox[0] + candidates[:, 0] * (bbox[2] - bbox[0])
+        ys = bbox[1] + candidates[:, 1] * (bbox[3] - bbox[1])
+
+        for x, y in zip(xs, ys):
+            if _contains(hull, x, y):
+                accepted.append((x, y))
+
+        result[i_replication] = numpy.asarray(accepted)
 
     return result.squeeze()

--- a/pointpats/random.py
+++ b/pointpats/random.py
@@ -702,6 +702,7 @@ def strauss(
 
     return result.squeeze()
 
+
 def sobol(
         hull,
         intensity=None,
@@ -755,13 +756,13 @@ def sobol(
     --------
     Generate 100 Sobol points in the unit square.
 
-    >>> points = sobol([0, 0, 1, 1], size=100, seed=123)
+    >>> points = sobol(numpy.array([0, 0, 1, 1]), size=100, seed=123)
     >>> points.shape
     (100, 2)
 
     Generate 3 independent replications.
 
-    >>> points = sobol([0, 0, 1, 1], size=(100, 3), seed=123)
+    >>> points = sobol(numpy.array([0, 0, 1, 1]), size=(100, 3), seed=123)
     >>> points.shape
     (3, 100, 2)
     """
@@ -804,6 +805,7 @@ def sobol(
         result[i_replication] = numpy.asarray(accepted)
 
     return result.squeeze()
+
 
 def halton(
         hull,
@@ -858,13 +860,13 @@ def halton(
     --------
     Generate 100 Halton points in the unit square.
 
-    >>> points = halton([0, 0, 1, 1], size=100, seed=123)
+    >>> points = halton(numpy.array([0, 0, 1, 1]), size=100, seed=123)
     >>> points.shape
     (100, 2)
 
     Generate 3 independent replications.
 
-    >>> points = halton([0, 0, 1, 1], size=(100, 3), seed=123)
+    >>> points = halton(numpy.array([0, 0, 1, 1]), size=(100, 3), seed=123)
     >>> points.shape
     (3, 100, 2)
     """
@@ -893,6 +895,98 @@ def halton(
             remaining = n_observations - len(accepted)
 
             candidates = hltn.random(remaining)
+
+            xs = bbox[0] + candidates[:, 0] * (bbox[2] - bbox[0])
+            ys = bbox[1] + candidates[:, 1] * (bbox[3] - bbox[1])
+
+            for x, y in zip(xs, ys, strict=True):
+                if _contains(hull, x, y):
+                    accepted.append((x, y))
+
+        result[i_replication] = numpy.asarray(accepted)
+
+    return result.squeeze()
+
+
+def r2(hull, intensity=None, size=None, seed=None):
+    """
+    Simulate a point pattern using the Roberts R2 low-discrepancy sequence.
+
+    Parameters
+    ----------
+    hull : A geometry-like object
+        This encodes the "space" in which to simulate the pattern.
+        All points will lie within this hull. Supported values are:
+
+        - a bounding box encoded as ``numpy.array([xmin, ymin, xmax, ymax])``
+        - an (N,2) array of points for which the bounding box will be computed & used
+        - a shapely polygon/multipolygon
+        - a scipy convex hull
+
+    intensity : float
+        The number of observations per unit area in the hull to use. If
+        provided, then ``size`` must be an integer describing the number of
+        replications to generate.
+
+    size : tuple or int
+        A tuple of ``(n_observations, n_replications)``, where the first
+        number is the number of points to simulate in each replication and
+        the second number is the number of replications. If an integer is
+        provided and ``intensity`` is None, one replication is generated.
+        If an integer is provided and ``intensity`` is also supplied, the
+        integer specifies the number of replications and the number of
+        observations is computed from the intensity.
+
+    seed : int or None, optional
+        Seed used to initialize the R2 sequence. If None, a random seed
+        is used.
+
+    Returns
+    -------
+    numpy.ndarray
+        Either an ``(n_replications, n_observations, 2)`` array or an
+        ``(n_observations, 2)`` array containing the simulated realizations.
+
+    Examples
+    --------
+    Generate 100 R2 points in the unit square.
+
+    >>> points = r2(numpy.array([0, 0, 1, 1]), size=100, seed=123)
+    >>> points.shape
+    (100, 2)
+
+    Generate 3 independent replications.
+
+    >>> points = r2(numpy.array([0, 0, 1, 1]), size=(100, 3), seed=123)
+    >>> points.shape
+    (3, 100, 2)
+    """
+    if isinstance(hull, numpy.ndarray):
+        hull = hull if hull.shape == (4,) else _prepare_hull(hull)
+
+    n_observations, n_simulations, intensity = parse_size_and_intensity(
+        hull, intensity=intensity, size=size
+    )
+
+    result = numpy.empty((n_simulations, n_observations, 2))
+
+    bbox = _bbox(hull)
+
+    phi2 = 1.324717957244746
+    alpha = numpy.array([1.0 / phi2, 1.0 / phi2**2])
+
+    for i_replication in range(n_simulations):
+        rng_seed = None if seed is None else seed + i_replication
+        offset = float(numpy.random.default_rng(rng_seed).random())
+        accepted = []
+        n_generated = 0
+
+        while len(accepted) < n_observations:
+            remaining = n_observations - len(accepted)
+            
+            indices = numpy.arange(n_generated + 1, n_generated + remaining + 1)
+            candidates = (offset + numpy.outer(indices, alpha)) % 1.0
+            n_generated += remaining
 
             xs = bbox[0] + candidates[:, 0] * (bbox[2] - bbox[0])
             ys = bbox[1] + candidates[:, 1] * (bbox[3] - bbox[1])

--- a/pointpats/random.py
+++ b/pointpats/random.py
@@ -886,20 +886,20 @@ def halton(
             seed=None if seed is None else seed + i_replication,
         )
 
-    accepted = []
+        accepted = []
 
-    while len(accepted) < n_observations:
+        while len(accepted) < n_observations:
 
-        remaining = n_observations - len(accepted)
+            remaining = n_observations - len(accepted)
 
-        candidates = hltn.random(remaining)
+            candidates = hltn.random(remaining)
 
-        xs = bbox[0] + candidates[:, 0] * (bbox[2] - bbox[0])
-        ys = bbox[1] + candidates[:, 1] * (bbox[3] - bbox[1])
+            xs = bbox[0] + candidates[:, 0] * (bbox[2] - bbox[0])
+            ys = bbox[1] + candidates[:, 1] * (bbox[3] - bbox[1])
 
-        for x, y in zip(xs, ys, strict=True):
-            if _contains(hull, x, y):
-                accepted.append((x, y))
+            for x, y in zip(xs, ys, strict=True):
+                if _contains(hull, x, y):
+                    accepted.append((x, y))
 
         result[i_replication] = numpy.asarray(accepted)
 

--- a/pointpats/tests/test_random.py
+++ b/pointpats/tests/test_random.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from pointpats.random import halton, sobol
+
+
+# -----------------------------------------------------------------------------
+# Sobol tests
+# -----------------------------------------------------------------------------
+def test_sobol_shape():
+    hull = np.array([0, 0, 1, 1])
+    points = sobol(hull, size=10)
+    assert points.shape == (10, 2)
+
+def test_sobol_multiple_replications():
+    hull = np.array([0, 0, 1, 1])
+    points = sobol(hull, size=(10, 4))
+    assert points.shape == (4, 10, 2)
+
+def test_sobol_reproducible():
+    hull = np.array([0, 0, 1, 1])
+    p1 = sobol(hull, size=100, seed=123)
+    p2 = sobol(hull, size=100, seed=123)
+    np.testing.assert_allclose(p1, p2)
+
+# -----------------------------------------------------------------------------
+# Halton tests
+# -----------------------------------------------------------------------------
+def test_halton_shape():
+    hull = np.array([0, 0, 1, 1])
+    points = halton(hull, size=10)
+    assert points.shape == (10, 2)
+
+def test_halton_multiple_replications():
+    hull = np.array([0, 0, 1, 1])
+    points = halton(hull, size=(10, 4))
+    assert points.shape == (4, 10, 2)
+
+def test_halton_reproducible():
+    hull = np.array([0, 0, 1, 1])
+    p1 = halton(hull, size=100, seed=123)
+    p2 = halton(hull, size=100, seed=123)
+    np.testing.assert_allclose(p1, p2)


### PR DESCRIPTION
Implements part of #209 

Added Sobol and Halton quasi-random low-discrepancy sequence generators.

I am not very familiar with QMC methods, so the implementations were largely based on the structure of the existing generators in `random.py` and my understanding of the SciPy documentation. I also created `test_random.py` and added a few basic tests covering output shape and reproducibility.

I am using rejection sampling for this which could be a potential concern and might need additional tests. If my understanding is correct, cases where the hull occupies only a small fraction of its bounding box (for example, a thin diagonally oriented polygon) could result in poor acceptance rates which would require many iterations before the requested number of points is generated and the current implementation does not impose a maximum iteration limit, which means it could go on for a long time.

If the overall approach looks reasonable, I can continue working on the remaining generators. From what I could gather, their implementation will also be largely similar.